### PR TITLE
fix: 跨平台兼容加固 — shebang 文件锁定 LF + copilot 命令 shell 回退

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,14 @@
 # shell 脚本固定 LF（Linux/macOS 执行安全，不受平台检出影响）
 *.sh text eol=lf
 
+# 带 shebang 的 Node 可执行脚本固定 LF（Windows 检出 CRLF 会破坏 POSIX shebang，
+# 导致 npm 全局安装后 bin 命令在 Linux/macOS 上报 bad interpreter）
+bin/*.js text eol=lf
+en/bin/*.js text eol=lf
+scripts/install-lib.js text eol=lf
+en/scripts/install-lib.js text eol=lf
+skills/*/scripts/*.mjs text eol=lf
+
 # 二进制文件（禁止文本转换）
 *.png binary
 *.tgz binary

--- a/en/scripts/install-lib.js
+++ b/en/scripts/install-lib.js
@@ -282,12 +282,30 @@ function installCopilot(log) {
   const sh = path.join(PKG_ROOT, 'install.sh')
   if (process.platform === 'win32' && fs.existsSync(ps1)) {
     log.step('运行 install.ps1（VS Code Copilot 侧导入）')
-    const pwsh = spawnSync('pwsh', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ps1], { stdio: 'inherit' })
-    if (pwsh.status !== 0) { log.warn(`install.ps1 退出码 ${pwsh.status}`); process.exitCode = pwsh.status ?? 1 }
+    // 优先 pwsh（7.x）；未安装时回退系统自带 Windows PowerShell 5.1
+    let r = null
+    for (const cmd of ['pwsh', 'powershell']) {
+      r = spawnSync(cmd, ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ps1], { stdio: 'inherit' })
+      if (!(r.error && r.error.code === 'ENOENT')) break
+      log.warn(`${cmd} 不可用，尝试下一个可用 shell`)
+    }
+    if (r && r.error && r.error.code === 'ENOENT') {
+      log.warn('未找到 pwsh / powershell（install.ps1 需要其中之一）')
+      process.exitCode = 1
+    } else if (r.status !== 0) {
+      log.warn(`install.ps1 退出码 ${r.status}`)
+      process.exitCode = r.status ?? 1
+    }
   } else if (fs.existsSync(sh)) {
     log.step('运行 install.sh（VS Code Copilot 侧导入）')
     const r = spawnSync('bash', [sh], { stdio: 'inherit' })
-    if (r.status !== 0) { log.warn(`install.sh 退出码 ${r.status}`); process.exitCode = r.status ?? 1 }
+    if (r.error && r.error.code === 'ENOENT') {
+      log.warn('未找到 bash（install.sh 需要 bash，可安装 bash 后重试）')
+      process.exitCode = 1
+    } else if (r.status !== 0) {
+      log.warn(`install.sh 退出码 ${r.status}`)
+      process.exitCode = r.status ?? 1
+    }
   } else {
     log.warn('未找到 install.ps1 / install.sh')
     process.exitCode = 1

--- a/scripts/install-lib.js
+++ b/scripts/install-lib.js
@@ -282,12 +282,30 @@ function installCopilot(log) {
   const sh = path.join(PKG_ROOT, 'install.sh')
   if (process.platform === 'win32' && fs.existsSync(ps1)) {
     log.step('运行 install.ps1（VS Code Copilot 侧导入）')
-    const pwsh = spawnSync('pwsh', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ps1], { stdio: 'inherit' })
-    if (pwsh.status !== 0) { log.warn(`install.ps1 退出码 ${pwsh.status}`); process.exitCode = pwsh.status ?? 1 }
+    // 优先 pwsh（7.x）；未安装时回退系统自带 Windows PowerShell 5.1
+    let r = null
+    for (const cmd of ['pwsh', 'powershell']) {
+      r = spawnSync(cmd, ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ps1], { stdio: 'inherit' })
+      if (!(r.error && r.error.code === 'ENOENT')) break
+      log.warn(`${cmd} 不可用，尝试下一个可用 shell`)
+    }
+    if (r && r.error && r.error.code === 'ENOENT') {
+      log.warn('未找到 pwsh / powershell（install.ps1 需要其中之一）')
+      process.exitCode = 1
+    } else if (r.status !== 0) {
+      log.warn(`install.ps1 退出码 ${r.status}`)
+      process.exitCode = r.status ?? 1
+    }
   } else if (fs.existsSync(sh)) {
     log.step('运行 install.sh（VS Code Copilot 侧导入）')
     const r = spawnSync('bash', [sh], { stdio: 'inherit' })
-    if (r.status !== 0) { log.warn(`install.sh 退出码 ${r.status}`); process.exitCode = r.status ?? 1 }
+    if (r.error && r.error.code === 'ENOENT') {
+      log.warn('未找到 bash（install.sh 需要 bash，可安装 bash 后重试）')
+      process.exitCode = 1
+    } else if (r.status !== 0) {
+      log.warn(`install.sh 退出码 ${r.status}`)
+      process.exitCode = r.status ?? 1
+    }
   } else {
     log.warn('未找到 install.ps1 / install.sh')
     process.exitCode = 1


### PR DESCRIPTION
## 背景

审查 npm 包 Linux/Windows 跨平台兼容性时发现两个问题：

1. **发布链路隐患**：.gitattributes 只锁定 *.sh 为 LF，带 shebang 的 Node 脚本（bin/*.js、scripts/install-lib.js、skills/*/scripts/*.mjs）只受 text=auto 约束。Windows（core.autocrlf=true）检出后直接 npm pack/publish，tarball 中 bin 带 CRLF，Linux/macOS 上 npm 全局安装后报 bad interpreter。
2. **kixparadigm copilot 命令**：Windows 分支 spawnSync('pwsh',...) 依赖 PowerShell 7，Windows 默认只有 5.1，未装 pwsh 时 ENOENT 失败。

## 改动

- .gitattributes：bin/*.js、en/bin/*.js、scripts/install-lib.js、en/scripts/install-lib.js、skills/*/scripts/*.mjs 固定 text eol=lf
- scripts/install-lib.js + en/scripts/install-lib.js：copilot 命令 Windows 侧 pwsh 不可用时回退 powershell 5.1（install.ps1 已确认 5.1 兼容）；POSIX 侧 bash 缺失时报清晰错误

## 验证（真实链路）

- node --check 两份脚本通过；ENOENT 检测逻辑实测
- git check-attr eol：6 个 shebang 文件全部 eol: lf
- npm pack 解包检查：bin 无 CRLF，shebang 正确
- npm install（隔离 DSH_HOME 指向 TEMP）：postinstall 完整执行，preset + vision-bridge + junction + cordis.patch.yml 就位
- Windows bin shim 三件套生成，kixparadigm.cmd --version → 1.1.4
- kixparadigm doctor：3 个插件测试 24 passed / 0 failed
