### PR TITLE
docs: sync README CN/EN to v1.2.13 state

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,9 @@
 
 > **AI self-orchestrated minimal paradigm (resident cognition layer) × multi-agent orchestration × coding-agent preset** — the whole kix family in one repository: one-command `npm` import into DeepSeek Harness, script import into VS Code Copilot.
 
-[![License](https://img.shields.io/badge/license-MIT-green)]()
+[![CI](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml/badge.svg)](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/kixparadigm)](https://www.npmjs.com/package/kixparadigm)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)]()
 
 > **中文版:** [README.md](README.md) · **English:** this file
@@ -11,7 +13,7 @@
 
 ## 🧭 Why this repository exists: the kix × DSH fit
 
-kix started as a **VS Code Copilot customization bundle**: resident cognition instructions, 17 skills, 6 team agents, 5 slash commands, mechanical-guard hooks, methodology memories — an AI self-orchestration system refined inside the Copilot ecosystem.
+kix started as a **VS Code Copilot customization bundle**: resident cognition instructions, 17 skills, 6 team agents, 5 slash commands, mechanical-guard hooks, methodology memories — an AI self-orchestration system refined inside the Copilot ecosystem (in this repo: the DSH preset carries all 17 skills; the Copilot distribution ships 7 of them).
 
 When we studied **DeepSeek Harness (DSH)**, we found the two are a **natural fit** — not a port, but "mechanism matching mechanism":
 
@@ -112,6 +114,8 @@ kix is layered in two, and this repository ships both layers plus the ecosystem 
 
 > **v1.2.13 (2026-08-17) deployment re-verification fixes**: ① handoff-gate mechanical injection — `kix-focus` auto-carries `current_sprint: N` on orchestration-member (qa/dev/reviewer) capability_call dispatch (workspace-marker driven, `sprintInjected` returned) + `kix-orchestration` v10.1 Tri-Block `[CONTEXT]` `Sprint N` tolerant parsing (double insurance, covers direct-dispatch paths); ② lite tier usable on Linux — `ACTIVATABLE_TOOLS` snapshot toolFilter made platform-conditional (v1.2.12 only fixed the agent.cordis.yml row, so the capability_call auto-activation path still failed with unknown global tool "pwsh"; proven by deployment E2E); ③ kix-guards v10.1 commit-on-main full-chain fix (`commit` added to `DANGEROUS_GIT`). Unit suites: kix-focus **102** / kix-orchestration **77** / kix-guards **219** all green; WSL2 deployment E2E re-verification passed (lite / commit interception / persona rule + mechanical-injection evidence).
 >
+> **v1.2.12 (2026-08-17) iterate-verify-release**: ① subagent-lite toolFilter.allow made platform-conditional (win32→pwsh, others→bash) — the hardcoded pwsh broke Linux deployments with an unknown-global-tool error from tools.restrict(), leaving the lite tier unusable (proven by WSL2 E2E); ② kix-guards v10: repoRootFromText now extracts the `cd <repo> && git commit` (no -C) command position — when the session cwd ≠ repo root the commit check silently skipped; unit suite grew 142→213; ③ persona: sprint dispatch contract lines now carry `current_sprint: N` so the kix-orchestration handoff gate actually fires; ④ jobs made resident + tier/goal auto-activate-on-first-use synced (see PR #6).
+>
 > **v1.2.11 soft-gate rectification (DSH editions)**: publish/comment/merge/destructive actions are off by default; an explicit user instruction ("comment on the PR") is the decision, so the model executes directly and kix-guards no longer re-asks per operation. Questions are reserved for genuinely missing decision information.
 >
 > **v1.2.10 rectification (DSH editions)**: fixes the KIX self-audit "0% false-positive" counterexamples — QA completion detection now excludes negated statements; control-plane guard only blocks write intent (`grep/cat/ls ~/.dsh` pass); terminal SQL uses command-position + SQL-payload statement analysis; GitHub MCP prefix is configurable; cross-vendor routing skips unregistered preference candidates; uninstalling one bilingual package no longer removes the shared vision-bridge; `engines` aligned with `process.getBuiltinModule`; resident persona second debt pass down to ~1.8K tokens (CN, was ~3.1K); persona-budget / doc-count / bilingual-parity guard and CI added; vision-bridge got regression tests and a complete-code-fence cleanup fix.
@@ -128,6 +132,9 @@ kixparadigm/
 │   ├── install-lib.js               ← cross-platform installer (preset + vision-bridge mount)
 │   ├── sync-dsh-preset.ps1          ← dev workflow: mirror dsh/preset → ~/.dsh (one-way)
 │   ├── ensure-vision-bridge.ps1     ← vision-bridge self-check/self-heal
+│   ├── check-dsh-consistency.cjs    ← persona budget / doc-count / bilingual-parity guard
+│   ├── install-kix-stalled.ps1      ← enable the optional kix-stalled plugin (opt-in)
+│   ├── list-plugin-tools.cjs / quantify-focus.cjs / wsl-restart-dsh.sh ← tool inventory / focus quantification / WSL helpers
 │   └── verify-*.js / .cjs           ← guard and load-chain verification
 │
 ├── dsh/                             ← DSH side (single source of truth)
@@ -135,8 +142,10 @@ kixparadigm/
 │   │   ├── agent.cordis.yml         ← composition (resident cognition persona + all capability rows)
 │   │   ├── preset.yml               ← roster display metadata
 │   │   ├── DSH-ADAPTATION.md        ← authoritative mechanism mapping (tools/guards/orchestration/vision)
+│   │   ├── DSH-FUSION-MATRIX.md     ← mechanism fusion matrix
+│   │   ├── PLUGINIZATION-ROADMAP.md ← pluginization roadmap (2026-08-16)
 │   │   ├── skills/  agents/  prompts/  instructions/  memories/
-│   │   └── plugins/                 ← kix-guards.js + kix-commands.js + tests
+│   │   └── plugins/                 ← kix-guards + kix-discipline + kix-orchestration + kix-focus + kix-cost + kix-route + kix-commands + kix-stalled (opt-in) + tests
 │   ├── vision-bridge/               ← dsh-vision-bridge plugin source (client + server + package.json)
 │   └── README-DSH.md                ← DSH deployment notes
 │
@@ -146,6 +155,7 @@ kixparadigm/
 │   ├── bridge/  bin/  scripts/      ← vision-bridge copy, CLI, parameterized installer
 │   └── README.md                    ← EN package readme
 │
+├── .github/workflows/ci.yml         ← CI: ubuntu+windows × node 20/22 dual-package tests + pack dry-run
 ├── skills/  agents/  prompts/  memories/  instructions/   ← VS Code Copilot distribution (kept as-is)
 ├── plugins/                         ← Copilot-side kix-guards original
 ├── install.ps1 / install.sh / INSTALL.md   ← Copilot install scripts
@@ -160,7 +170,7 @@ kixparadigm/
 ## 🧪 Development & verification
 
 ```bash
-npm test                                  # consistency guard + full regression: installer 12 + vision-bridge 6 + guards 210 + discipline 68 + orchestration 69 + focus 73 + cost 28 + route 68 assertions (+ commands 6 groups)
+npm test                                  # consistency guard + full regression: installer 12 + vision-bridge 6 + guards 219 + discipline 68 + orchestration 77 + focus 102 + cost 28 + route 68 assertions (+ commands 6 groups)
 node scripts/check-dsh-consistency.cjs       # persona budget / doc counts / bilingual plugin parity guard
 node scripts/verify-guards.js             # compare installed preset vs bundle guards
 node scripts/verify-vision-bridge-resolution.cjs  # vision-bridge load-chain full path

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 > **AI 自编排最小范式（认知层常驻）× 多智能体编排 × 编码 Agent 预设** — 一个仓库装下 kix 全家桶，`npm` 一键导入 DeepSeek Harness，脚本导入 VS Code Copilot。
 
-[![License](https://img.shields.io/badge/license-MIT-green)]()
+[![CI](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml/badge.svg)](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/kixparadigm)](https://www.npmjs.com/package/kixparadigm)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)]()
 
 > **🌍 English:** [README.en.md](README.en.md) · **中文:** 本文件
@@ -11,7 +13,7 @@
 
 ## 🧭 为什么会有这个仓库：kix × DSH 的适配研究
 
-kix 范式最初是 **VS Code Copilot 定制包**：常驻认知指令、17 个技能、6 个团队 Agent、5 个 slash 命令、机械门禁 hooks、方法论记忆——一套在 Copilot 生态里打磨出来的 AI 自编排体系。
+kix 范式最初是 **VS Code Copilot 定制包**：常驻认知指令、17 个技能、6 个团队 Agent、5 个 slash 命令、机械门禁 hooks、方法论记忆——一套在 Copilot 生态里打磨出来的 AI 自编排体系（本仓库内：DSH preset 收录全部 17 技能，Copilot 分发版含其中 7 个）。
 
 后来我们研究了 **DeepSeek Harness（DSH）**，发现两者是**天然适配**的——不是移植，而是"机制对上机制"：
 
@@ -112,6 +114,8 @@ kix 体系分两层，本仓库把两层 + 生态依赖一次性装齐：
 
 > **v1.2.13（2026-08-17）部署复验整改**：① 交接 gate 机械注入——`kix-focus` 编曲成员（qa/dev/reviewer）capability_call 分派自动携带 `current_sprint: N`（工作区 marker 驱动，`sprintInjected` 返回）+ `kix-orchestration` v10.1 Tri-Block `[CONTEXT]` `Sprint N` 容错解析（双保险，直呼路径也兜底）；② lite 档 Linux 可用——`ACTIVATABLE_TOOLS` 快照 toolFilter 平台条件化（v1.2.12 只修了 agent.cordis.yml 行，capability_call 自动激活路径仍报 unknown global tool "pwsh"，部署 E2E 实锤）；③ kix-guards v10.1 commit-on-main 整链修复（`DANGEROUS_GIT` 补 `commit`）。单测：kix-focus **102** / kix-orchestration **77** / kix-guards **219** 组全绿；WSL2 部署 E2E 三复验全过（lite / commit 拦截 / persona 规则 + 机械注入实证）。
 >
+> **v1.2.12（2026-08-17）迭代-验证-发布**：① subagent-lite toolFilter.allow 平台条件化（win32→pwsh、其余→bash）——原硬编码 pwsh 使 Linux 部署 tools.restrict() 报 unknown global tool、lite 档不可用（WSL2 E2E 实证）；② kix-guards v10：repoRootFromText 补 `cd <repo> && git commit`（无 -C）命令位提取——会话 cwd ≠ 仓库根时 commit 检查此前静默跳过，单元回归 142→213 组；③ persona：Sprint 子代理分派契约行补 `current_sprint: N`，使 kix-orchestration 交接门禁真正触发；④ jobs 常驻化 + 细分档位/goal 首次使用自动激活（详见 PR #6）。
+>
 > **v1.2.11 软约束整改（DSH 版）**：发布/评论/合并/破坏默认不做；用户明确指示（如「评论到PR」）即已决策，直接执行，kix-guards 不再逐次提问。提问只留给真正缺失的决策信息。
 >
 > **v1.2.10 整改（DSH 版）**：按 KIX 自审修复「0% 误报」反例——QA 完成声明排除负向表述；控制平面门禁只拦写意图（`grep/cat/ls ~/.dsh` 放行）；终端 SQL 改为 DB 客户端命令位 + SQL payload 语句级判定；GitHub MCP 前缀可配置；跨厂商路由跳过未注册偏好候选；中英包卸载不再互相删除共享 vision-bridge；`engines` 对齐 `process.getBuiltinModule` 最低版本；常驻 persona 二次还债压至约 1.8K token（CN，原 3.1K）；新增 persona 预算/文档计数/双语插件一致性守护与 CI；vision-bridge 补纯逻辑回归并修复完整代码围栏剥离。
@@ -128,6 +132,9 @@ kixparadigm/
 │   ├── install-lib.js               ← 跨平台安装器（preset + vision-bridge 挂载）
 │   ├── sync-dsh-preset.ps1          ← 日常开发：镜像 dsh/preset → ~/.dsh（单向）
 │   ├── ensure-vision-bridge.ps1     ← vision-bridge 自检/自愈
+│   ├── check-dsh-consistency.cjs    ← persona 预算/文档计数/双语一致性守护
+│   ├── install-kix-stalled.ps1      ← 启用可选 kix-stalled 插件（opt-in）
+│   ├── list-plugin-tools.cjs / quantify-focus.cjs / wsl-restart-dsh.sh ← 工具清单/聚焦量化/WSL 辅助
 │   └── verify-*.js / .cjs           ← 门禁与加载链验证
 │
 ├── dsh/                             ← DSH 侧（唯一事实源）
@@ -135,12 +142,19 @@ kixparadigm/
 │   │   ├── agent.cordis.yml         ← 组成（persona 常驻认知层 + 全部能力行）
 │   │   ├── preset.yml               ← roster 显示元数据
 │   │   ├── DSH-ADAPTATION.md        ← 权威机制映射（工具名/门禁/编排/vision）
+│   │   ├── DSH-FUSION-MATRIX.md     ← 机制融合矩阵
 │   │   ├── PLUGINIZATION-ROADMAP.md ← 插件化改造路线图（2026-08-16）
 │   │   ├── skills/  agents/  prompts/  instructions/  memories/
 │   │   └── plugins/                 ← kix-guards + kix-discipline + kix-orchestration + kix-focus + kix-cost + kix-route + kix-commands + kix-stalled（opt-in）+ 测试
 │   ├── vision-bridge/               ← dsh-vision-bridge 插件源码（client + server + package.json）
 │   └── README-DSH.md                ← DSH 部署说明
 │
+├── en/                              ← 英文版（独立 npm 包 kixparadigm-en，与中文包同步发版）
+│   ├── preset/                      ← EN preset 事实源（persona/指令/术语表已译；技能/提示词/记忆翻译中）
+│   ├── bridge/  bin/  scripts/      ← vision-bridge 副本、CLI、参数化安装器
+│   └── README.md                    ← EN 包 readme
+│
+├── .github/workflows/ci.yml         ← CI：ubuntu+windows × node 20/22 双包测试 + pack dry-run
 ├── skills/  agents/  prompts/  memories/  instructions/   ← VS Code Copilot 分发版（原样保留）
 ├── plugins/                         ← Copilot 侧 kix-guards 原件
 ├── install.ps1 / install.sh / INSTALL.md   ← Copilot 安装脚本
@@ -155,7 +169,7 @@ kixparadigm/
 ## 🧪 开发与验证
 
 ```bash
-npm test                                  # 一致性守护 + 全插件回归：installer 12 + vision-bridge 6 + 门禁 210 + 纪律 68 + 编排 69 + 聚焦 73 + 成本 28 + 路由 68 断言（+ commands 6 组）
+npm test                                  # 一致性守护 + 全插件回归：installer 12 + vision-bridge 6 + 门禁 219 + 纪律 68 + 编排 77 + 聚焦 102 + 成本 28 + 路由 68 断言（+ commands 6 组）
 node scripts/check-dsh-consistency.cjs       # 单独跑 persona 预算/文档计数/双语插件一致性守护
 node scripts/verify-guards.js             # 已安装 preset 与 bundle 门禁对照
 node scripts/verify-vision-bridge-resolution.cjs  # vision-bridge 加载链全链路


### PR DESCRIPTION
## Summary

两阶段文档整改:

### 阶段 1:数字同步(475e945)
- npm test 断言计数 210/69/73 → 实测 219/77/102(双版)
- 补 v1.2.12 注记(PR #6 素材)、en/ 与 .github/ 结构、CI/npm 徽章、「17 vs 7 技能」叙述校准

### 阶段 2:README 作为范式自指重写(47a8781)
按 kix 哲学实践于文档本身:
- **规则是负债 → 文档是负债**:常驻最小。192/194 → 77/77 行
- **渐进披露(kix-focus)→ 按需路由**:版本史 → CHANGELOG.md(新建);机制细节 → DSH-ADAPTATION.md 链接;README 只留「是什么/怎么装/怎么验」
- **唯一事实源 → 消灭双源**:易变断言计数不再写进 README,由 `npm test` 输出自报——计数漂移这类漏更从结构上不可能再发生

守护断言(`+ 4 记忆` 双语短语)保留,结构树保留唯一事实源约定块。

## Verification
- [x] `node scripts/check-dsh-consistency.cjs` → CONSISTENCY OK
- [x] `npm test` 全绿(exit 0)
- [x] README CN/EN 行数 77/77(对齐),CHANGELOG 收录 v1.2.9→v1.2.13 全部演进
- [x] 徽章指向真实 workflow/npm 包

文档-only 变更,不影响运行时。