### PR TITLE
docs: rewrite README as paradigm self-reference (slim, single-source)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## v1.2.13（2026-08-17）部署复验整改
+
+- **交接 gate 机械注入**：`kix-focus` 编曲成员（qa/dev/reviewer）capability_call 分派自动携带 `current_sprint: N`（工作区 marker `docs/.kixpower-current-sprint` 驱动，`sprintInjected` 返回）+ `kix-orchestration` v10.1 Tri-Block `[CONTEXT]` `Sprint N` 容错解析（双保险，直呼路径也兜底）
+- **lite 档 Linux 可用**：`ACTIVATABLE_TOOLS` 快照 toolFilter 平台条件化（v1.2.12 只修了 agent.cordis.yml 行，capability_call 自动激活路径仍报 unknown global tool "pwsh"，部署 E2E 实锤）
+- **kix-guards v10.1**：commit-on-main 整链修复——`DANGEROUS_GIT` 补 `commit`。此前纯 `git commit` 不触发 isGitWrite、分支/预算检查永不执行，main 直接 commit 静默放行（部署 E2E 实锤）
+- 单测：kix-focus **102** / kix-orchestration **77** / kix-guards **219** 组全绿；WSL2 部署 E2E 三复验全过（lite / commit 拦截 / persona 规则 + 机械注入实证）
+
+## v1.2.12（2026-08-17）iterate-verify-release（PR #6）
+
+- subagent-lite toolFilter.allow 平台条件化（win32→pwsh、其余→bash）——原硬编码 pwsh 使 Linux 部署 tools.restrict() 报 unknown global tool、lite 档不可用（WSL2 E2E 实证）
+- kix-guards v10：repoRootFromText 补 `cd <repo> && git commit`（无 -C）命令位提取——会话 cwd ≠ 仓库根时 commit 检查此前静默跳过，单元回归 142→213 组
+- persona：Sprint 子代理分派契约行补 `current_sprint: N`，使 kix-orchestration 交接门禁真正触发
+- jobs 常驻化 + 细分档位/goal 首次使用自动激活（capability_call 代理即挂载，kix_tool_activate 保留为显式预激活）
+- kix-focus symlink 部署跨平台解析修复：候选根链 argv[1]→realpath→插件文件，WSL2 E2E 两轮实测闭环
+
+## v1.2.11 软约束整改（DSH 版）
+
+- 发布/评论/合并/破坏默认不做；用户明确指示（如「评论到PR」）即已决策，直接执行，kix-guards 不再逐次提问。提问只留给真正缺失的决策信息
+
+## v1.2.10 整改（DSH 版）
+
+- 按 KIX 自审修复「0% 误报」反例——QA 完成声明排除负向表述；控制平面门禁只拦写意图（`grep/cat/ls ~/.dsh` 放行）；终端 SQL 改为 DB 客户端命令位 + SQL payload 语句级判定；GitHub MCP 前缀可配置；跨厂商路由跳过未注册偏好候选；中英包卸载不再互相删除共享 vision-bridge；`engines` 对齐 `process.getBuiltinModule` 最低版本
+- 常驻 persona 二次还债压至约 1.8K token（CN，原 3.1K）
+- 新增 persona 预算/文档计数/双语插件一致性守护与 CI；vision-bridge 补纯逻辑回归并修复完整代码围栏剥离
+
+## 更早
+
+- v1.2.9：编曲模型（activatable 成员档 + Sprint 流程）、kix-discipline 插件化、kix-route modelPreference 配置化
+- v1.2.8 及以前：见 git log

--- a/README.en.md
+++ b/README.en.md
@@ -1,84 +1,32 @@
 # kixparadigm
 
-> **AI self-orchestrated minimal paradigm (resident cognition layer) × multi-agent orchestration × coding-agent preset** — the whole kix family in one repository: one-command `npm` import into DeepSeek Harness, script import into VS Code Copilot.
+> **Minimal self-orchestration paradigm (resident cognition) × multi-agent orchestration × coding agent presets** — the full kix stack in one repo: one-command import into DeepSeek Harness, scripted import into VS Code Copilot.
 
 [![CI](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml/badge.svg)](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/kixparadigm)](https://www.npmjs.com/package/kixparadigm)
+[![npm](https://img.shields.io/npm/v/kixparadigm-en)](https://www.npmjs.com/package/kixparadigm-en)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)]()
 
-> **中文版:** [README.md](README.md) · **English:** this file
+> **🌍 English:** this file · **中文:** [README.md](README.md)
+>
+> This document practices the repo's own paradigm: **resident minimum, progressive disclosure, no dual-sourced volatile numbers** — version history lives in [CHANGELOG.md](CHANGELOG.md), mechanism mapping in [dsh/preset/DSH-ADAPTATION.md](dsh/preset/DSH-ADAPTATION.md); details are not duplicated here.
 
----
+## Why
 
-## 🧭 Why this repository exists: the kix × DSH fit
+The kix paradigm began as a VS Code Copilot customization pack. Studying DeepSeek Harness (DSH) revealed a **natural mechanism fit**: resident cognition = preset persona, guard hooks = `tools/pre-execute` plugins, team agents = subagent dispatch, slash commands = native DSH commands, vision top-up = vision-bridge. Full mapping: [DSH-ADAPTATION.md](dsh/preset/DSH-ADAPTATION.md) and [DSH-FUSION-MATRIX.md](dsh/preset/DSH-FUSION-MATRIX.md).
 
-kix started as a **VS Code Copilot customization bundle**: resident cognition instructions, 17 skills, 6 team agents, 5 slash commands, mechanical-guard hooks, methodology memories — an AI self-orchestration system refined inside the Copilot ecosystem (in this repo: the DSH preset carries all 17 skills; the Copilot distribution ships 7 of them).
+The fit turns the paradigm from "one person's local Copilot customization" into "a reproducible public asset installable in one command" — that is why this repo is open source.
 
-When we studied **DeepSeek Harness (DSH)**, we found the two are a **natural fit** — not a port, but "mechanism matching mechanism":
-
-| kix mechanism | DSH native carrier | Verdict |
-|---|---|---|
-| Resident cognition instructions (how to think) | preset persona (active every session) | ✅ direct equivalent |
-| PreToolUse mechanical-guard hooks (blast-radius / source protection / dangerous git) | **`kix-guards` plugin** (`tools/pre-execute` listener) + host sandbox/approval stack | ✅ a stronger guard host |
-| `/kixpower-*` slash commands | **`kix-commands` plugin** (DSH native commands, zero-token trigger) | ✅ commands as entry points |
-| Team agents (Producer/Dev/QA/Reviewer) | DSH subagent dispatch (role prompt templates) | ✅ orchestration lands directly |
-| Skill system | DSH skills (customSkillDirs inside the preset) | ✅ mounted as-is |
-| memory-tool methodology memories | DSH memories/ (read on demand per persona) | ✅ mounted as-is |
-| Cross-vendor model validation (a kix core belief) | DSH llm-pi-ai providers + `subagent_vision` vision subagent | ✅ native support |
-| Vision compensation for non-vision main models | **`dsh-vision-bridge` plugin** (GLM-4.6V auto-describe) | ✅ seamless in the UI |
-
-The research conclusions live in [`dsh/preset/DSH-ADAPTATION.md`](dsh/preset/DSH-ADAPTATION.md) (the authoritative mechanism mapping). The practical payoff: **kix went from "one person's local Copilot customization" to "a public asset reproducible with one command"** — that is why this repository is open source: any DSH environment can get the complete kix cognition layer + execution layer + guards + vision compensation in one step.
-
----
-
-## 🚀 Quick start (DSH, recommended)
-
-### Option 1: npm one-command import (`npm i -g` completes the whole install)
+## Quick start (DSH, recommended)
 
 ```bash
-npm i -g kixparadigm
+npm i -g kixparadigm     # preset + vision-bridge auto-install; restart dsh web and pick kixparadigm in the mode list
+npx kixparadigm install  # no global install
+npm i -g kixparadigm-en  # English edition (separate package; translation status: en/preset/TRANSLATION-STATUS.md)
 ```
 
-The install does everything automatically:
+Custom DSH dir (`DSH_HOME`), `--preset-only`, ops commands (`doctor` / `uninstall` / `copilot`): see [dsh/README-DSH.md](dsh/README-DSH.md).
 
-1. **Preset** → `~/.dsh/.agent-presets/kixparadigm/` (full preset: persona cognition layer + 17 skills + 6 roles + 5 commands + guard/command plugins + 4 memories)
-2. **vision-bridge** → `~/.dsh/profiles/web/plugins/dsh-vision-bridge/` (junction created automatically, `cordis.patch.yml` entry registered)
-3. **Checklist**: warns when `settings.yaml` lacks the `zai-vision` / `zai-coding-cn` providers (fill them in per `DSH-ADAPTATION.md`)
-
-Then **restart dsh web** (Ctrl+C → `dsh web`) and pick **kixparadigm** in the new-session mode list.
-
-> Custom DSH directory: `DSH_HOME=/path/to/dsh npm i -g kixparadigm` (default `~/.dsh`)
-> Skip vision-bridge: `kixparadigm install --preset-only`
-
-### Option 2: npx (no global install)
-
-```bash
-npx kixparadigm install
-```
-
-### 🌍 English edition
-
-The resident cognition layer (persona / core instructions / glossary / main-entry agent) is fully translated — see the canonical terminology table in [`en/preset/instructions/glossary.md`](en/preset/instructions/glossary.md):
-
-```bash
-npm i -g kixparadigm-en     # installs the kixparadigm-en preset (mode picker: kixparadigm-en)
-kixparadigm-en doctor       # self-check
-```
-
-Deep-mechanism docs (skills / prompts / memories / team roles) are still the Chinese originals while translation progresses — status tracked in [`en/preset/TRANSLATION-STATUS.md`](en/preset/TRANSLATION-STATUS.md). Source of the EN edition: the `en/` directory (npm package root) + `en/preset/` (EN preset source of truth).
-
-### Operations
-
-```bash
-kixparadigm doctor        # self-check: preset / links / mount entries / plugin unit regressions
-kixparadigm uninstall     # remove everything installed
-kixparadigm copilot       # (optional) also import the VS Code Copilot side
-```
-
----
-
-## 🚀 Quick start (VS Code Copilot)
+## Quick start (VS Code Copilot)
 
 ```bash
 # Windows
@@ -87,108 +35,43 @@ kixparadigm copilot       # (optional) also import the VS Code Copilot side
 chmod +x install.sh && ./install.sh
 ```
 
-Details in [INSTALL.md](INSTALL.md). After installing, reload the window and type `/kixpower-new` / `/kixpower-import` / `/kixpower-continue` / `/kixpower-review` after `/`.
+See [INSTALL.md](INSTALL.md). Start with `/kixpower-new`.
 
----
+## What this is: two layers + plugin floor
 
-## 📦 What this is: two layers
+| Layer | Component | One-liner |
+|-------|-----------|-----------|
+| **Cognition** (how to think) | kixparadigm persona | Three-channel cross-validation, phase duality, rules-are-debt, requirement triple-check (no user-pleasing), pre-code decision chain |
+| **Execution** (how to execute) | kixpower | Orchestration model: lead model freely picks members (dev/qa/reviewer) + Sprint flow, DAG topology, 4-layer loop, four invariant floors |
+| Mechanical guards | `kix-guards` | Commit budget, feature branch, force push, dangerous SQL, control-plane protection (hard deny only for irreversible damage) |
+| Handoff discipline | `kix-orchestration` · `kix-discipline` | Subagent handoff evidence-chain checks; spec contract gate + verification gate |
+| Focus | `kix-focus` | Tool surface 85→18 resident cut + on-demand catalog & proxied execution — progressive disclosure at runtime |
+| Cost & routing | `kix-cost` · `kix-route` | Subagent thinking-effort normalization; sentinel model names → runtime-available routes |
+| Top-up | `kix-commands` · `dsh-vision-bridge` · `kix-stalled` (opt-in) | `/kixpower-*` native commands; vision for blind lead models; stalled-Sprint detection |
 
-kix is layered in two, and this repository ships both layers plus the ecosystem dependencies in one go:
+Preset in full: persona + 17 skills + 6 roles + 5 commands + 4 memories. Per-plugin mechanics and evolution: [DSH-ADAPTATION.md](dsh/preset/DSH-ADAPTATION.md), [CHANGELOG.md](CHANGELOG.md).
 
-| Layer | Component | Role |
-|---|---|---|
-| **Cognition layer (how to think)** | `kixparadigm` | Resident cognition paradigm: Three-Channel Cross-Validation, Phase Duality, Rules Are Liabilities, Triple Requirement Check (no sycophancy), Pre-Code Decision Chain, AI Blind-Spot Map. Active in every session |
-| **Execution layer (how to execute)** | `kixpower` | **Arranger model (v1.2.9)**: the main model freely picks members + flow — dev/qa/reviewer activatable member tiers (names as contract handles) + kixpower sprint flow (heavy path), DAG topology, 4-level loop, verifiable gates; four floor invariants (observation independence / coordination in main thread / perspectives from prompts / gates unchanged) |
-| **Ecosystem skills** | `handoff` / `write-a-skill` / `improve-codebase-architecture` and 17 more | Session handoff, skill authoring, architecture improvement, TDD/teaching/diagnosis methodology |
-| **Mechanical guards** | `kix-guards` plugin | Commit budget, feature branch, force push, dangerous SQL, control-plane file protection (**219 assertions**; v9 demotes publish/comment/ordinary-push confirmation gates to soft constraints — no repeated questions; hard deny remains only for irreversible destruction: force push / main protection / destructive SQL / control-plane writes / remote deletion; **v10.1 (2026-08-17) fixes the commit-on-main full-chain dead code**: `commit` added to `DANGEROUS_GIT` — previously a plain `git commit` never entered the git-write gate, so the branch/budget check never ran and direct commits to main silently passed (proven by deployment E2E)) |
-| **Discipline mechanism** | `kix-discipline` plugin | Triple-check contract gate + verification gate: spec contract checked before implementation edits, end-of-turn no-test reminder, `kix_discipline_spec` contract tool (v1.2.9 optional `mode` field = arranger trace: member composition + one-line reason), `/kix-discipline` command (68 assertions, 2026-08-16 pluginization P0; v2 reject/handoff ask; mode placeholder round-trip + header-regex escaping fix 2026-08-17) |
-| **Orchestration handoff gate** | `kix-orchestration` plugin | Pre-dispatch checks (sprint marker / plan+progress / blocker / QA completeness); v2 QA return-side consistency (subagent/end); v3 producer_closeout evidence chain; v4 sleep-waiting-for-subagent one-shot reminder (**v4.1 platform-agnostic**: dual command shapes always tested, no tool-name gating; WSL2-verified positive+negative); v8 negative-semantics QA completion guard; **v10.1 (2026-08-17) Tri-Block tolerance**: when the contract line is absent, `Sprint N` is parsed from the `[CONTEXT]` segment as a fallback (handoff-gate mechanical backstop for direct-dispatch paths; 77 assertions) |
-| **Minimal + progressive disclosure** | `kix-focus` plugin | Three tiers: tools.restrict trims the per-turn tool surface from 85 (~108KB schema) to ~18 resident core; `kix_capability_search` on-demand catalog (v4 param-name metadata + long-tail fallback groups) + `kix_capability_call` proxied execution (full guard pipeline); v1.2.12 jobs made resident (mechanical background-task control surface, fixes the "no job controller serves this agent" run_in_background error) + tiers/goal **auto-activate on first use** (capability_call mounts on demand, no pre-activation needed; kix_tool_activate stays as explicit pre-activation; v1.2.9 enumeration-sync regression guard + **cross-platform symlink-install resolution fix**: candidate-root chain argv[1]→realpath→plugin file, WSL2 E2E two-round closed loop); PTC/Code Mode interop (**102 assertions**; **v1.2.13 handoff-gate mechanical backstop**: orchestration members qa/dev/reviewer dispatched via capability_call get `current_sprint: N` auto-injected from the workspace `docs/.kixpower-current-sprint` (`sprintInjected` returned), and the lite tier `ACTIVATABLE_TOOLS` snapshot is now platform-conditional (v1.2.12 dual-source miss, proven by deployment E2E)) |
-| **Cost discipline** | `kix-cost` plugin | Subagent reasoning-effort normalization (thinker→max, other deepseek→high) + lite-tier preferred-route probing with automatic fallback (28 assertions, v5.8; multi-round fallback-route cache fix 2026-08-17) |
-| **Routing layer** | `kix-route` plugin | Sentinel model names (`kix-route:cross/vision/thinker`) → runtime route resolution: cross-vendor inversion / vision model / deep-thinking tier; configurable preference tables (`modelPreference`/`crossProviderOrder` via plugin config, 2026-08-17) (68 assertions, v5.9.1) |
-| **Native commands** | `kix-commands` plugin | `/kixpower-*` five commands registered as DSH native commands (zero-token trigger, inject flows from `prompts/`) |
-| **Stalled detection** | `kix-stalled` plugin (optional) | `/kixst-check` command + `kix_stalled_check` tool: read-only detection of stalled sprints (candidate, commented-out mount = opt-in, enable via `scripts/install-kix-stalled.ps1`) |
-| **Vision compensation** | `dsh-vision-bridge` plugin | When the main model has no vision, pasted/dropped images are auto-converted to text descriptions before submit (GLM-4.6V, server HTTP + client dock) |
-
-**In one sentence**: kixparadigm gives the AI the freedom of "how to think" plus blind-spot compensation; kixpower gives "how to execute" structured team orchestration; the guard and vision plugins make DSH a complete host for kix.
-
-> **v1.2.13 (2026-08-17) deployment re-verification fixes**: ① handoff-gate mechanical injection — `kix-focus` auto-carries `current_sprint: N` on orchestration-member (qa/dev/reviewer) capability_call dispatch (workspace-marker driven, `sprintInjected` returned) + `kix-orchestration` v10.1 Tri-Block `[CONTEXT]` `Sprint N` tolerant parsing (double insurance, covers direct-dispatch paths); ② lite tier usable on Linux — `ACTIVATABLE_TOOLS` snapshot toolFilter made platform-conditional (v1.2.12 only fixed the agent.cordis.yml row, so the capability_call auto-activation path still failed with unknown global tool "pwsh"; proven by deployment E2E); ③ kix-guards v10.1 commit-on-main full-chain fix (`commit` added to `DANGEROUS_GIT`). Unit suites: kix-focus **102** / kix-orchestration **77** / kix-guards **219** all green; WSL2 deployment E2E re-verification passed (lite / commit interception / persona rule + mechanical-injection evidence).
->
-> **v1.2.12 (2026-08-17) iterate-verify-release**: ① subagent-lite toolFilter.allow made platform-conditional (win32→pwsh, others→bash) — the hardcoded pwsh broke Linux deployments with an unknown-global-tool error from tools.restrict(), leaving the lite tier unusable (proven by WSL2 E2E); ② kix-guards v10: repoRootFromText now extracts the `cd <repo> && git commit` (no -C) command position — when the session cwd ≠ repo root the commit check silently skipped; unit suite grew 142→213; ③ persona: sprint dispatch contract lines now carry `current_sprint: N` so the kix-orchestration handoff gate actually fires; ④ jobs made resident + tier/goal auto-activate-on-first-use synced (see PR #6).
->
-> **v1.2.11 soft-gate rectification (DSH editions)**: publish/comment/merge/destructive actions are off by default; an explicit user instruction ("comment on the PR") is the decision, so the model executes directly and kix-guards no longer re-asks per operation. Questions are reserved for genuinely missing decision information.
->
-> **v1.2.10 rectification (DSH editions)**: fixes the KIX self-audit "0% false-positive" counterexamples — QA completion detection now excludes negated statements; control-plane guard only blocks write intent (`grep/cat/ls ~/.dsh` pass); terminal SQL uses command-position + SQL-payload statement analysis; GitHub MCP prefix is configurable; cross-vendor routing skips unregistered preference candidates; uninstalling one bilingual package no longer removes the shared vision-bridge; `engines` aligned with `process.getBuiltinModule`; resident persona second debt pass down to ~1.8K tokens (CN, was ~3.1K); persona-budget / doc-count / bilingual-parity guard and CI added; vision-bridge got regression tests and a complete-code-fence cleanup fix.
-
----
-
-## 📂 Repository layout
+## Repo layout
 
 ```
 kixparadigm/
-├── package.json                     ← npm packaging (postinstall auto-install, bin provides the CLI)
-├── bin/kixparadigm.js               ← CLI: install / uninstall / doctor / copilot
-├── scripts/
-│   ├── install-lib.js               ← cross-platform installer (preset + vision-bridge mount)
-│   ├── sync-dsh-preset.ps1          ← dev workflow: mirror dsh/preset → ~/.dsh (one-way)
-│   ├── ensure-vision-bridge.ps1     ← vision-bridge self-check/self-heal
-│   ├── check-dsh-consistency.cjs    ← persona budget / doc-count / bilingual-parity guard
-│   ├── install-kix-stalled.ps1      ← enable the optional kix-stalled plugin (opt-in)
-│   ├── list-plugin-tools.cjs / quantify-focus.cjs / wsl-restart-dsh.sh ← tool inventory / focus quantification / WSL helpers
-│   └── verify-*.js / .cjs           ← guard and load-chain verification
-│
-├── dsh/                             ← DSH side (single source of truth)
-│   ├── preset/                      ← the mirror of ~/.dsh/.agent-presets/kixparadigm/
-│   │   ├── agent.cordis.yml         ← composition (resident cognition persona + all capability rows)
-│   │   ├── preset.yml               ← roster display metadata
-│   │   ├── DSH-ADAPTATION.md        ← authoritative mechanism mapping (tools/guards/orchestration/vision)
-│   │   ├── DSH-FUSION-MATRIX.md     ← mechanism fusion matrix
-│   │   ├── PLUGINIZATION-ROADMAP.md ← pluginization roadmap (2026-08-16)
-│   │   ├── skills/  agents/  prompts/  instructions/  memories/
-│   │   └── plugins/                 ← kix-guards + kix-discipline + kix-orchestration + kix-focus + kix-cost + kix-route + kix-commands + kix-stalled (opt-in) + tests
-│   ├── vision-bridge/               ← dsh-vision-bridge plugin source (client + server + package.json)
-│   └── README-DSH.md                ← DSH deployment notes
-│
-├── en/                              ← English edition (npm package root)
-│   ├── package.json                 ← name: kixparadigm-en
-│   ├── preset/                      ← EN preset source of truth (EN persona/instructions/glossary; CN skills/prompts/memories pending)
-│   ├── bridge/  bin/  scripts/      ← vision-bridge copy, CLI, parameterized installer
-│   └── README.md                    ← EN package readme
-│
-├── .github/workflows/ci.yml         ← CI: ubuntu+windows × node 20/22 dual-package tests + pack dry-run
-├── skills/  agents/  prompts/  memories/  instructions/   ← VS Code Copilot distribution (kept as-is)
-├── plugins/                         ← Copilot-side kix-guards original
-├── install.ps1 / install.sh / INSTALL.md   ← Copilot install scripts
-├── vision-bench/                    ← vision load-chain benchmark assets (A/B timing)
-└── README.md  README.en.md  LICENSE  .gitignore
+├── dsh/preset/        ← DSH preset source of truth: persona/skills/roles/plugin sources+tests/adaptation docs
+├── en/                ← English edition (separate npm package kixparadigm-en, released in sync with CN)
+├── skills/ agents/ prompts/ memories/ instructions/   ← VS Code Copilot distribution (7-skill subset)
+├── bin/ scripts/      ← CLI and install/verify/consistency-guard scripts
+└── install.ps1 / install.sh / INSTALL.md / CHANGELOG.md
 ```
 
-> **Single-source-of-truth convention**: `dsh/preset/` is the source of truth for the DSH preset; `~/.dsh/.agent-presets/kixparadigm/` is only the installed copy. Maintain the preset by editing `dsh/preset/` then running `scripts/sync-dsh-preset.ps1 -Force` (EN edition: `-PresetId kixparadigm-en -SourceDir en\preset`). The root `skills/` etc. are the Copilot distribution and deliberately differ from the DSH copies — don't overwrite one with the other.
+> **Source-of-truth convention**: `dsh/preset/` is the source of truth; `~/.dsh/.agent-presets/kixparadigm/` is only an installed copy (maintain = edit preset, then run `scripts/sync-dsh-preset.ps1 -Force`); root `skills/` etc. are the Copilot distribution, deliberately different from the DSH edition — do not overwrite either way.
 
----
-
-## 🧪 Development & verification
+## Development & verification
 
 ```bash
-npm test                                  # consistency guard + full regression: installer 12 + vision-bridge 6 + guards 219 + discipline 68 + orchestration 77 + focus 102 + cost 28 + route 68 assertions (+ commands 6 groups)
-node scripts/check-dsh-consistency.cjs       # persona budget / doc counts / bilingual plugin parity guard
-node scripts/verify-guards.js             # compare installed preset vs bundle guards
-node scripts/verify-vision-bridge-resolution.cjs  # vision-bridge load-chain full path
-pwsh -File .\scripts\sync-dsh-preset.ps1 -DryRun   # preview preset diffs
-kixparadigm doctor                        # install state self-check
+npm test                                    # consistency guard + full plugin regression (counts self-reported by test output, not maintained in this doc)
+node scripts/check-dsh-consistency.cjs      # persona budget/doc counts/bilingual consistency guard
+kixparadigm doctor                          # install self-check
 ```
 
-Preset mount validation (roster `standingKeyFor`) runs inside a DSH session using the cordis toolset.
-
-## 📢 Publishing
-
-```bash
-npm login                      # first time
-npm test && npm pack --dry-run # pre-publish self-check
-npm publish                    # publish (CN edition)
-npm publish ./en               # publish EN edition (kixparadigm-en)
-```
-
-## 📄 License
+## License
 
 [MIT](LICENSE) © 2026 kixparadigm contributors

--- a/README.md
+++ b/README.md
@@ -5,80 +5,28 @@
 [![CI](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml/badge.svg)](https://github.com/olicesx/kixparadigm/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/kixparadigm)](https://www.npmjs.com/package/kixparadigm)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)]()
 
 > **🌍 English:** [README.en.md](README.en.md) · **中文:** 本文件
+>
+> 本文档实践仓库自身的范式：**常驻最小、渐进披露、易变数字不双源维护** —— 版本史在 [CHANGELOG.md](CHANGELOG.md)，机制映射在 [dsh/preset/DSH-ADAPTATION.md](dsh/preset/DSH-ADAPTATION.md)，细节不在此重复。
 
----
+## 为什么
 
-## 🧭 为什么会有这个仓库：kix × DSH 的适配研究
+kix 范式原是 VS Code Copilot 定制包。研究 DeepSeek Harness（DSH）后发现两者**机制天然适配**：常驻认知 = preset persona、门禁 hooks = `tools/pre-execute` 插件、团队 Agent = subagent 分派、slash 命令 = DSH 原生命令、识图补足 = vision-bridge。完整映射见 [DSH-ADAPTATION.md](dsh/preset/DSH-ADAPTATION.md) 与 [DSH-FUSION-MATRIX.md](dsh/preset/DSH-FUSION-MATRIX.md)。
 
-kix 范式最初是 **VS Code Copilot 定制包**：常驻认知指令、17 个技能、6 个团队 Agent、5 个 slash 命令、机械门禁 hooks、方法论记忆——一套在 Copilot 生态里打磨出来的 AI 自编排体系（本仓库内：DSH preset 收录全部 17 技能，Copilot 分发版含其中 7 个）。
+适配带来一个现实转变：范式从「一个人本机的 Copilot 定制」变成「一条命令可复现的公开资产」——这是本仓库开源的契机。
 
-后来我们研究了 **DeepSeek Harness（DSH）**，发现两者是**天然适配**的——不是移植，而是"机制对上机制"：
-
-| kix 机制 | DSH 原生载体 | 适配结论 |
-|---|---|---|
-| 常驻认知指令（怎么思考） | preset persona（每次会话自动生效） | ✅ 直接等价 |
-| PreToolUse 机械门禁 hooks（blast-radius / 源码保护 / 危险 git） | **自研 `kix-guards` 插件**（`tools/pre-execute` 监听器）+ host sandbox/approval 栈 | ✅ 更强的门禁宿主 |
-| `/kixpower-*` slash 命令 | **自研 `kix-commands` 插件**（DSH 原生命令，零 token 触发） | ✅ 命令即入口 |
-| 团队 Agent（Producer/Dev/QA/Reviewer） | DSH subagent 分派（角色 prompt 模板） | ✅ 编排直接落地 |
-| 技能体系（skills） | DSH skills（preset 内 customSkillDirs） | ✅ 原样挂载 |
-| memory-tool 方法论记忆 | DSH memories/（persona 指引按需读取） | ✅ 原样挂载 |
-| 跨厂商模型验证（kix 核心信念之一） | DSH llm-pi-ai providers + `subagent_vision` 视觉子代理 | ✅ 原生支持 |
-| 无视觉主模型的识图补足 | **自研 `dsh-vision-bridge` 插件**（GLM-4.6V 自动转描述） | ✅ UI 无缝 |
-
-研究结论记录在 [`dsh/preset/DSH-ADAPTATION.md`](dsh/preset/DSH-ADAPTATION.md)（权威机制映射）。这套适配带来了一个现实收益：**kix 范式从"一个人本机的 Copilot 定制"变成了"一条命令可复现的公开资产"**——这就是本仓库开源的契机：让任何 DSH 环境都能一键获得完整的 kix 认知层 + 执行层 + 门禁 + 识图补足。
-
----
-
-## 🚀 快速开始（DSH，推荐）
-
-### 方式一：npm 一键导入（`npm i -g` 自动完成全部安装）
+## 快速开始（DSH，推荐）
 
 ```bash
-npm i -g kixparadigm
+npm i -g kixparadigm     # preset + vision-bridge 全自动安装，重启 dsh web 后在模式列表选 kixparadigm
+npx kixparadigm install  # 不全局安装
+npm i -g kixparadigm-en  # 英文版（独立包，翻译状态见 en/preset/TRANSLATION-STATUS.md）
 ```
 
-安装过程自动完成：
+自定义 DSH 目录（`DSH_HOME`）、`--preset-only`、运维命令（`doctor` / `uninstall` / `copilot`）见 [dsh/README-DSH.md](dsh/README-DSH.md)。
 
-1. **preset** → `~/.dsh/.agent-presets/kixparadigm/`（完整 preset：persona 认知层 + 17 技能 + 6 角色 + 5 命令 + 门禁/命令插件 + 4 记忆）
-2. **vision-bridge** → `~/.dsh/profiles/web/plugins/dsh-vision-bridge/`（自动建 junction、登记 `cordis.patch.yml` 挂载条目）
-3. **检查清单**：`settings.yaml` 缺 `zai-vision` / `zai-coding-cn` provider 时会提示（按 `DSH-ADAPTATION.md` 补齐）
-
-然后**重启 dsh web**（Ctrl+C → `dsh web`），新会话模式列表里选择 **kixparadigm** 即可。
-
-> 自定义 DSH 目录：`DSH_HOME=/path/to/dsh npm i -g kixparadigm`（默认 `~/.dsh`）
-> 不想装 vision-bridge：`kixparadigm install --preset-only`
-
-### 方式二：npx（不全局安装）
-
-```bash
-npx kixparadigm install
-```
-
-### 🌍 English edition
-
-The resident cognition layer (persona / core instructions / glossary / main-entry agent) is fully translated — see the canonical terminology table in [`en/preset/instructions/glossary.md`](en/preset/instructions/glossary.md):
-
-```bash
-npm i -g kixparadigm-en     # installs the kixparadigm-en preset (mode picker: kixparadigm-en)
-kixparadigm-en doctor       # self-check
-```
-
-Deep-mechanism docs (skills / prompts / memories / team roles) are still the Chinese originals while translation progresses — status tracked in [`en/preset/TRANSLATION-STATUS.md`](en/preset/TRANSLATION-STATUS.md). Source of the EN edition: the `en/` directory (npm package root) + `en/preset/` (EN preset source of truth).
-
-### 常用运维命令
-
-```bash
-kixparadigm doctor        # 自检：preset/链接/挂载条目/插件单元回归
-kixparadigm uninstall     # 卸载全部安装内容（另一语言包仍安装时保留共享 vision-bridge）
-kixparadigm copilot       # （可选）同时导入 VS Code Copilot 侧
-```
-
----
-
-## 🚀 快速开始（VS Code Copilot）
+## 快速开始（VS Code Copilot）
 
 ```bash
 # Windows
@@ -87,106 +35,43 @@ kixparadigm copilot       # （可选）同时导入 VS Code Copilot 侧
 chmod +x install.sh && ./install.sh
 ```
 
-详细说明见 [INSTALL.md](INSTALL.md)。装完重载窗口，`/` 输入 `/kixpower-new` / `/kixpower-import` / `/kixpower-continue` / `/kixpower-review`。
+详见 [INSTALL.md](INSTALL.md)。装完 `/kixpower-new` 开始。
 
----
+## 这是什么：两层 + 插件地板
 
-## 📦 这是什么：两层结构
+| 层 | 组件 | 一句话 |
+|----|------|--------|
+| **认知层**（怎么思考） | kixparadigm persona | 三通道交叉验证、阶段二相性、规则是负债、需求三检（不迎合用户）、写码前决策链 |
+| **执行层**（怎么执行） | kixpower | 编曲模型：主模型自由挑成员（dev/qa/reviewer）+ Sprint 流程、DAG 拓扑、4 层 loop、四条不变量地板 |
+| 机械门禁 | `kix-guards` | commit 预算、feature branch、force push、危险 SQL、控制面保护（硬 deny 仅不可逆破坏） |
+| 交接纪律 | `kix-orchestration` · `kix-discipline` | subagent 交接证据链校验；spec 契约 gate + 验证 gate |
+| 聚焦 | `kix-focus` | 工具面 85→18 常驻裁剪 + 按需目录与代理执行——渐进披露的运行时形态 |
+| 成本路由 | `kix-cost` · `kix-route` | 子代理思考强度归一化；哨兵模型名 → 运行时可用路由 |
+| 补足 | `kix-commands` · `dsh-vision-bridge` · `kix-stalled`（opt-in） | `/kixpower-*` 原生命令；无视觉主模型识图；停滞 Sprint 检测 |
 
-kix 体系分两层，本仓库把两层 + 生态依赖一次性装齐：
+preset 全量：persona + 17 技能 + 6 角色 + 5 命令 + 4 记忆。各插件机制与版本演进见 [DSH-ADAPTATION.md](dsh/preset/DSH-ADAPTATION.md) 与 [CHANGELOG.md](CHANGELOG.md)。
 
-| 层 | 组件 | 作用 |
-|----|------|------|
-| **认知层（怎么思考）** | `kixparadigm` | 常驻认知范式：三通道交叉验证、阶段二相性、规则是负债、需求三检（不迎合用户）、写码前决策链、AI 盲点补足。每个会话自动生效 |
-| **执行层（怎么执行）** | `kixpower` | **编曲模型（v1.2.9）**：主模型自由挑成员+流程——dev/qa/reviewer 三个 activatable 成员档（人名=契约句柄）+ kixpower Sprint 流程（重路径）、DAG 拓扑、4 层 loop、可验证 gate；四条不变量地板（观察独立性/协调主线程/视角来自 prompt/门禁不变） |
-| **生态辅助** | `handoff` / `write-a-skill` / `improve-codebase-architecture` 等 17 技能 | 会话交接、技能创建、架构改进、TDD/教学/排查等通用方法论 |
-| **机械门禁** | `kix-guards` 插件 | commit budget、feature branch、force push、危险 SQL、控制面文件保护（**219 组断言**；v9 起发布/评论/普通 push 等确认类门禁降为软约束，不再提问；硬 deny 仅保留 force push / main 保护 / 破坏性 SQL / 控制平面写 / 删除远端数据等不可逆破坏；**v10.1（2026-08-17）修复 commit-on-main 整链死代码**：`DANGEROUS_GIT` 补 `commit`——此前纯 `git commit` 不触发 isGitWrite、分支/预算检查永不执行，main 直接 commit 静默放行（部署 E2E 实锤）） |
-| **纪律机制化** | `kix-discipline` 插件 | 需求三检契约 gate + 验证 gate：实现编辑前查 spec 契约、回合结束无测试提醒、`kix_discipline_spec` 契约工具（v1.2.9 新增可选 mode 字段=编曲留痕：成员组合+一句理由）、`/kix-discipline` 命令（68 组断言，2026-08-16 插件化改造 P0；拒绝/转交弹问 v2；mode 占位回读防假值 + 标题正则转义修复 2026-08-17） |
-| **编排交接门禁** | `kix-orchestration` 插件 | subagent 交接前校验 sprint marker / plan+progress / blocker / QA 完成度；v2 QA 返回侧一致性校验（subagent/end）；v3 producer_closeout 收尾证据链；v4 sleep 空转等待子代理一次性提醒（**v4.1 平台无关**：命令语义双形态恒测，不按工具名门控；WSL2 实测阳性/阴性双通过）；v8 QA 完成声明负向语义防误报；**v10.1（2026-08-17）Tri-Block 容错**：无契约行时从 `[CONTEXT]` 段兜底解析 `Sprint N`（交接 gate 机械兜底，直呼路径；共 77 组断言） |
-| **极简+渐进披露** | `kix-focus` 插件 | 三层递进：tools.restrict 把每轮工具面从 85 个（~108KB schema）裁到 ~18 个常驻核心集；`kix_capability_search` 按需查目录（v4 带参数名元数据 + 长尾兜底组：新装工具零配置即目录可达）+ `kix_capability_call` 代理执行（走完整门禁管线）；v1.2.12 jobs 常驻化（后台任务机械控制面，修 run_in_background 无控制器报错）+ 细分档位/goal **首次使用自动激活**（capability_call 代理即挂载，模型无需先激活；kix_tool_activate 保留为显式预激活；v1.2.9 枚举同步回归防线 + **symlink 部署跨平台解析修复**：候选根链 argv[1]→realpath→插件文件，WSL2 E2E 两轮实测闭环）；与 PTC/Code Mode 协同（**102 组断言**；**v1.2.13 交接 gate 机械兜底**：编曲成员 qa/dev/reviewer 经 capability_call 分派时按工作区 `docs/.kixpower-current-sprint` 自动注入契约行 `current_sprint: N`（`sprintInjected` 返回），并修 lite 档 `ACTIVATABLE_TOOLS` 快照平台条件化（v1.2.12 双源漏改，部署 E2E 实锤）） |
-| **成本纪律** | `kix-cost` 插件 | 子代理思考强度归一化（thinker→max、其余 deepseek→high）+ lite 档首选路由探测自动回退（28 组断言，v5.8；多轮回退路由缓存 bug 修复 2026-08-17） |
-| **路由层** | `kix-route` 插件 | 哨兵模型名（`kix-route:cross/vision/thinker`）→ 运行时可用路由自动解析：跨厂商取反/识图模型/深思考档位；偏好表可配置（`modelPreference`/`crossProviderOrder` 经插件 config 覆盖，2026-08-17）；v8 未注册偏好候选跳过（68 组断言，v5.9.1） |
-| **原生命令** | `kix-commands` 插件 | `/kixpower-*` 五命令注册为 DSH 原生命令（零 token 触发，读 `prompts/` 注入流程） |
-| **stalled 检测** | `kix-stalled` 插件（可选） | `/kixst-check` 命令 + `kix_stalled_check` 工具：只读检测停滞 Sprint（candidate，默认注释挂载 = opt-in，`scripts/install-kix-stalled.ps1` 启用） |
-| **识图补足** | `dsh-vision-bridge` 插件 | 主模型无视觉时，粘贴/拖入图片自动转文本描述再提交（GLM-4.6V，服务端 HTTP + client dock） |
-
-**关系一句话**：kixparadigm 给 AI「怎么思考」的自由度与盲点补足，kixpower 给「怎么执行」的结构化团队编排，门禁与识图插件把 DSH 变成 kix 的完整宿主。
-
-> **v1.2.13（2026-08-17）部署复验整改**：① 交接 gate 机械注入——`kix-focus` 编曲成员（qa/dev/reviewer）capability_call 分派自动携带 `current_sprint: N`（工作区 marker 驱动，`sprintInjected` 返回）+ `kix-orchestration` v10.1 Tri-Block `[CONTEXT]` `Sprint N` 容错解析（双保险，直呼路径也兜底）；② lite 档 Linux 可用——`ACTIVATABLE_TOOLS` 快照 toolFilter 平台条件化（v1.2.12 只修了 agent.cordis.yml 行，capability_call 自动激活路径仍报 unknown global tool "pwsh"，部署 E2E 实锤）；③ kix-guards v10.1 commit-on-main 整链修复（`DANGEROUS_GIT` 补 `commit`）。单测：kix-focus **102** / kix-orchestration **77** / kix-guards **219** 组全绿；WSL2 部署 E2E 三复验全过（lite / commit 拦截 / persona 规则 + 机械注入实证）。
->
-> **v1.2.12（2026-08-17）迭代-验证-发布**：① subagent-lite toolFilter.allow 平台条件化（win32→pwsh、其余→bash）——原硬编码 pwsh 使 Linux 部署 tools.restrict() 报 unknown global tool、lite 档不可用（WSL2 E2E 实证）；② kix-guards v10：repoRootFromText 补 `cd <repo> && git commit`（无 -C）命令位提取——会话 cwd ≠ 仓库根时 commit 检查此前静默跳过，单元回归 142→213 组；③ persona：Sprint 子代理分派契约行补 `current_sprint: N`，使 kix-orchestration 交接门禁真正触发；④ jobs 常驻化 + 细分档位/goal 首次使用自动激活（详见 PR #6）。
->
-> **v1.2.11 软约束整改（DSH 版）**：发布/评论/合并/破坏默认不做；用户明确指示（如「评论到PR」）即已决策，直接执行，kix-guards 不再逐次提问。提问只留给真正缺失的决策信息。
->
-> **v1.2.10 整改（DSH 版）**：按 KIX 自审修复「0% 误报」反例——QA 完成声明排除负向表述；控制平面门禁只拦写意图（`grep/cat/ls ~/.dsh` 放行）；终端 SQL 改为 DB 客户端命令位 + SQL payload 语句级判定；GitHub MCP 前缀可配置；跨厂商路由跳过未注册偏好候选；中英包卸载不再互相删除共享 vision-bridge；`engines` 对齐 `process.getBuiltinModule` 最低版本；常驻 persona 二次还债压至约 1.8K token（CN，原 3.1K）；新增 persona 预算/文档计数/双语插件一致性守护与 CI；vision-bridge 补纯逻辑回归并修复完整代码围栏剥离。
-
----
-
-## 📂 仓库结构
+## 仓库结构
 
 ```
 kixparadigm/
-├── package.json                     ← npm 打包（postinstall 自动安装，bin 提供 CLI）
-├── bin/kixparadigm.js               ← CLI：install / uninstall / doctor / copilot
-├── scripts/
-│   ├── install-lib.js               ← 跨平台安装器（preset + vision-bridge 挂载）
-│   ├── sync-dsh-preset.ps1          ← 日常开发：镜像 dsh/preset → ~/.dsh（单向）
-│   ├── ensure-vision-bridge.ps1     ← vision-bridge 自检/自愈
-│   ├── check-dsh-consistency.cjs    ← persona 预算/文档计数/双语一致性守护
-│   ├── install-kix-stalled.ps1      ← 启用可选 kix-stalled 插件（opt-in）
-│   ├── list-plugin-tools.cjs / quantify-focus.cjs / wsl-restart-dsh.sh ← 工具清单/聚焦量化/WSL 辅助
-│   └── verify-*.js / .cjs           ← 门禁与加载链验证
-│
-├── dsh/                             ← DSH 侧（唯一事实源）
-│   ├── preset/                      ← → ~/.dsh/.agent-presets/kixparadigm/ 的镜像
-│   │   ├── agent.cordis.yml         ← 组成（persona 常驻认知层 + 全部能力行）
-│   │   ├── preset.yml               ← roster 显示元数据
-│   │   ├── DSH-ADAPTATION.md        ← 权威机制映射（工具名/门禁/编排/vision）
-│   │   ├── DSH-FUSION-MATRIX.md     ← 机制融合矩阵
-│   │   ├── PLUGINIZATION-ROADMAP.md ← 插件化改造路线图（2026-08-16）
-│   │   ├── skills/  agents/  prompts/  instructions/  memories/
-│   │   └── plugins/                 ← kix-guards + kix-discipline + kix-orchestration + kix-focus + kix-cost + kix-route + kix-commands + kix-stalled（opt-in）+ 测试
-│   ├── vision-bridge/               ← dsh-vision-bridge 插件源码（client + server + package.json）
-│   └── README-DSH.md                ← DSH 部署说明
-│
-├── en/                              ← 英文版（独立 npm 包 kixparadigm-en，与中文包同步发版）
-│   ├── preset/                      ← EN preset 事实源（persona/指令/术语表已译；技能/提示词/记忆翻译中）
-│   ├── bridge/  bin/  scripts/      ← vision-bridge 副本、CLI、参数化安装器
-│   └── README.md                    ← EN 包 readme
-│
-├── .github/workflows/ci.yml         ← CI：ubuntu+windows × node 20/22 双包测试 + pack dry-run
-├── skills/  agents/  prompts/  memories/  instructions/   ← VS Code Copilot 分发版（原样保留）
-├── plugins/                         ← Copilot 侧 kix-guards 原件
-├── install.ps1 / install.sh / INSTALL.md   ← Copilot 安装脚本
-├── vision-bench/                    ← 识图链路基准资产（A/B 测速）
-└── README.md  LICENSE  .gitignore
+├── dsh/preset/        ← DSH preset 唯一事实源：persona/技能/角色/插件源码+测试/适配文档
+├── en/                ← 英文版（独立 npm 包 kixparadigm-en，与中文包同步发版）
+├── skills/ agents/ prompts/ memories/ instructions/   ← VS Code Copilot 分发版（7 技能子集）
+├── bin/ scripts/      ← CLI 与安装/验证/一致性守护脚本
+└── install.ps1 / install.sh / INSTALL.md / CHANGELOG.md
 ```
 
-> **唯一事实源约定**：`dsh/preset/` 是 DSH preset 的事实源；`~/.dsh/.agent-presets/kixparadigm/` 只是安装副本。维护 preset = 改 `dsh/preset/` 再跑 `scripts/sync-dsh-preset.ps1 -Force`。根目录 `skills/` 等是 Copilot 分发版，与 DSH 版刻意不同，不要互相覆盖。
+> **唯一事实源约定**：`dsh/preset/` 是事实源，`~/.dsh/.agent-presets/kixparadigm/` 只是安装副本（维护 = 改 preset 后跑 `scripts/sync-dsh-preset.ps1 -Force`）；根目录 `skills/` 等是 Copilot 分发版，与 DSH 版刻意不同，不互相覆盖。
 
----
-
-## 🧪 开发与验证
+## 开发与验证
 
 ```bash
-npm test                                  # 一致性守护 + 全插件回归：installer 12 + vision-bridge 6 + 门禁 219 + 纪律 68 + 编排 77 + 聚焦 102 + 成本 28 + 路由 68 断言（+ commands 6 组）
-node scripts/check-dsh-consistency.cjs       # 单独跑 persona 预算/文档计数/双语插件一致性守护
-node scripts/verify-guards.js             # 已安装 preset 与 bundle 门禁对照
-node scripts/verify-vision-bridge-resolution.cjs  # vision-bridge 加载链全链路
-pwsh -File .\scripts\sync-dsh-preset.ps1 -DryRun   # 预览 preset 差异
-kixparadigm doctor                        # 安装状态自检
+npm test                                    # 一致性守护 + 全插件回归（计数由测试输出自报，不在本文档维护）
+node scripts/check-dsh-consistency.cjs      # persona 预算/文档计数/双语一致性守护
+kixparadigm doctor                          # 安装状态自检
 ```
 
-preset 挂载校验（roster `standingKeyFor`）在 DSH 会话内用 cordis 工具集执行。
-
-## 📢 发布
-
-```bash
-npm login                      # 首次
-npm test && npm pack --dry-run # 发布前自检
-npm publish                    # 发布（npm i -g kixparadigm 即一键导入）
-```
-
-## 📄 License
+## License
 
 [MIT](LICENSE) © 2026 kixparadigm contributors


### PR DESCRIPTION
## Summary

补上 PR #8 中描述但**未合并**的「阶段 2」：README 作为范式自指重写（47a8781 在 PR #8 合并后才提交，成了孤儿 commit，从未进 main）。

- **规则是负债 → 文档是负债**：常驻最小。README CN/EN 192/194 → **77/77 行**
- **渐进披露 → 按需路由**：版本史迁移至新建的 CHANGELOG.md；机制细节已由 DSH-ADAPTATION.md 覆盖，README 只留「是什么/怎么装/怎么验」
- **唯一事实源 → 消灭双源**：易变断言计数不再写进 README，由 `npm test` 输出自报——计数漂移这类漏更从结构上不可能再发生

守护断言（`+ 4 记忆` 双语短语）保留，结构树保留唯一事实源约定块。

## Verification
- [x] rebase 到最新 main，零冲突（475e945 已在 main 中自动跳过）
- [x] `node scripts/check-dsh-consistency.cjs` → CONSISTENCY OK
- [x] `npm test` 全绿（exit 0，219/77/102 断言组）
- [x] README CN/EN 行数 77/77 对齐，CHANGELOG 收录 v1.2.9→v1.2.13 全部演进

文档-only 变更，不影响运行时。
