### PR TITLE
release: 1.3.5 (web_search resident + schema compression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.3.5（2026-08-20）web_search 恢复常驻 + 工具描述压缩
+
+- **web_search 三分法回滚（默认 preset）**：曾尝试把 `web_search` 从常驻挪到 `ACTIVATABLE_TOOLS` 渐进披露。评估否决——低频工具断 KV 缓存一次的成本（cacheRead:input 实测 127:1，长会话全价重读）远超省下的 ~660 tok/步常驻税；且 `tool-web` 是 preset 行注册的 scope-local 工具，`restrict` deny 裁不到（旧测试把 web_search 塞进全局视图断言 deny 含它 = 假绿）。本版：`agent.cordis.yml` 的 `tool-web` 恢复常驻；`ACTIVATABLE_TOOLS.web_search` 删除；`kix-focus` deny 清单不再假装能裁它；capability 目录 search 组改回「常驻可直接调用」。
+- **工具 schema 文案压缩（常驻税）**：缩短 `kix_capability_call` / `kix_tool_activate` / `kix_tool_deactivate` / `kix_discipline_spec` / `probe` / `experience` 的 description（保留行为锚点与何时用/何时不用；砍机制复述）。job 组 hint 改为「list 确认存在 → output 读结果 → kill 停止」。
+- **测试**：`kix-focus.test.js` 改断言——`web_search` 不在 ACTIVATABLE、restrict deny 不含它、常驻性由 cordis 行决定。四副本 identical（default / classic / null / en-classic）。
+- **npm 经典模式**：1.3.4 已修好 variants 安装面，本版保持 `kixparadigm` + `kixparadigm-classic`；en 仍为 `kixparadigm-classic-en`。
+
 ## v1.3.4（2026-08-20）persona 预算口径修正 + 经典模式随 npm 安装（1.3.1–1.3.4 首次进 registry）
 
 - **发版收口**：npm 上一次是 `kixparadigm@1.3.0` / `kixparadigm-en@1.2.23`。1.3.0 tarball **含** `dsh/preset-classic/`，但安装器只认单一 `presetDir`，postinstall 只把默认激励面拷到 `~/.dsh/.agent-presets/kixparadigm/`——用户反馈「发布的包没有经典模式」= 安装面漏装，不是打包漏文件。本版 `package.json#kixparadigm.variants` 声明 `kixparadigm` + `kixparadigm-classic`，安装器逐变体拷贝；en 包安装 id 对齐 `kixparadigm-classic-en`。`npm i -g kixparadigm` 后模式列表应同时出现两者。en 包从 1.2.23 跳到 1.3.4（中间 1.3.0–1.3.3 未单独发 en）。

--- a/dsh/preset-classic/plugins/kix-discipline.js
+++ b/dsh/preset-classic/plugins/kix-discipline.js
@@ -372,7 +372,7 @@ module.exports = {
     // ── 模型工具：记录需求三检契约 ────────────────────────────────────────
     const disposeSpecTool = tools.register({
       name: 'kix_discipline_spec',
-      description: '记录当前任务的需求三检契约（kix 需求三检：XY Problem / 前提假设 / 更优路径），写入工作区 kix-discipline/spec.md。需求三检后、开始实现编辑前调用；契约可跨会话复用。mode 字段（可选）= 编曲留痕：成员组合 + 一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
+      description: '记录需求三检契约（XY Problem / 前提假设 / 更优路径）到工作区 kix-discipline/spec.md。需求三检后、编辑前调用；跨会话复用。mode（可选）= 编曲留痕：成员组合+一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
       parameters: {
         // tools.register 原样投影 parameters：必须含顶层 type: 'object'
         type: 'object',

--- a/dsh/preset-classic/plugins/kix-focus.js
+++ b/dsh/preset-classic/plugins/kix-focus.js
@@ -70,8 +70,10 @@ const { readFileSync, statSync } = require('node:fs')
 // scope-local 名，代理反而失败）。故 SCOPE_RESIDENT 把它们纳入语义常驻集，
 // 目录/统计口径与实际可见面一致；capability_call 对它们拒绝（"请直接调用"）。
 // RESTRICT_ALLOW 是 allow 时代的白名单（现改用 deny 模式）；保留作统计/文档。
-// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻，
-// 加入 deny 清单（经 capability_call 代理）。
+// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻。
+// 2026-08-20 修正（系统提示词瘦身）：deny 方案从未生效——tool-web 是 preset
+// 行注册（scope-local），restrict 只作用于全局工具；真实裁法是 cordis 行
+// disabled + ACTIVATABLE_TOOLS.web_search 自动激活（见 ACTIVATABLE_TOOLS）。
 const RESTRICT_ALLOW = [
   // 全局基础工具（host 平面注册）
   'edit', 'write', 'read', 'grep', 'glob', 'pwsh', 'bash',
@@ -153,7 +155,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'jobs',
     title: '后台任务（job_output/job_list/job_kill）',
-    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动，job_output/job_list/job_kill 回收与停止',
+    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动；job_list 确认任务存在 → job_output 读结果 → job_kill 停止',
     tools: ['job_output', 'job_list', 'job_kill'],
   },
   {
@@ -171,7 +173,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'search',
     title: '网络搜索（web_search）',
-    hint: '低频（库文档优先 context7 MCP），默认按需：用 kix_capability_call 代理调用 web_search',
+    hint: '常驻可直接调用：外部信息检索用 web_search（库文档优先 context7 MCP）',
     tools: ['web_search'],
   },
   {
@@ -318,6 +320,9 @@ function makeUserMessage(text) {
 const CHILD_MAX_DEPTH = 2
 const CHILD_TOOL_DENY = ['exit_plan_mode', 'subagent', 'subagent_cross', 'interrupt_agent', 'send_message', 'list_agents', 'ask_user_question', 'kix_tool_activate', 'kix_tool_deactivate']
 const ACTIVATABLE_TOOLS = {
+  // 2026-08-20 三分法回滚：web_search 曾加入此处（渐进披露），评估否决——
+  // 低频 + 断 KV 缓存成本远超省下的常驻税，恢复 cordis tool-web 常驻。
+  // 见 dsh/preset/agent.cordis.yml tool-web 行注释（回滚理由完整记录）。
   workflow: { package: '@deepseek-ai/dsh-tool-workflow', config: {} },
   goal: { package: '@deepseek-ai/dsh-tool-goal', config: {} },
   // 2026-08-18 渐进披露扩容：kix-browser（本地插件，17 action 浏览器自动化）
@@ -628,7 +633,8 @@ module.exports = {
     function applyRestrict() {
       if (!enableRestrict) return
       const globals = globalSchemas()
-      // deny 目标 = 全部 MCP 全局工具 + web_search（低频，2026-08-16 移出常驻）
+      // deny 目标 = 全部 MCP 全局工具（scope-local 工具裁不到——web_search
+      // 2026-08-20 起由 cordis disabled + ACTIVATABLE 激活承担，见文件头）
       const denyTargets = globals.filter((s) => s.name && (s.name.startsWith('mcp__') || s.name === 'web_search')).map((s) => s.name)
       const fresh = denyTargets.filter((n) => !denied.has(n))
       if (fresh.length === 0) return // 无新增目标（或尚未注册），等 tools/change / 定时重试
@@ -640,7 +646,7 @@ module.exports = {
         restrictError = null
         clearRetry()
         ctx.effect(() => dispose)
-        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP+web_search，restrict 增量），scope 工具照常可见`)
+        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP，restrict 增量），scope 工具照常可见（按需工具走 cordis disabled + ACTIVATABLE 激活）`)
       } catch (e) {
         restrictError = e && e.message ? e.message : String(e)
         restrictDenyCount = denied.size
@@ -693,7 +699,7 @@ module.exports = {
     // ── Phase 2：kix_capability_call（代理执行 + 首次使用自动激活，常驻）──
     const disposeCall = tools.register({
       name: 'kix_capability_call',
-      description: '代理调用一个按需披露的工具（渐进披露的调用面）：执行目标工具并返回其结果。走完整 pre-execute→guards→execute→post-execute 管线（kix 门禁依然拦截）。MCP/cordis_* 等全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）会**首次使用自动激活**——本调用即挂载并执行、下一轮起可直接调用；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
+      description: '代理调用按需披露工具（走完整 pre-execute→guards→execute 管线，门禁仍拦）。MCP/cordis_* 全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）首次使用自动激活（本调用即挂载并执行、下一轮起直呼）；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
       parameters: {
         // tools.register 原样投影 parameters（不做 ValueSchemaSpec 转换）：
         // 必须传合法 JSON Schema，含顶层 type: 'object'。arguments 用 object +
@@ -877,7 +883,7 @@ module.exports = {
       // 2026-08-17 枚举 bug 修复：描述枚举曾漏 subagent_reviewer（集合有、
       // 描述无——模型照描述行事即永远激活不了它）；现与 ACTIVATABLE_TOOLS
       // 键集合同步（测试有回归防线），新增 qa/dev 一并列入。
-      description: '显式预激活一个默认未挂载的 scope 工具（细分档位与 goal）：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser（本地 kix-browser 插件，17 action 浏览器自动化，pkgPath 解析）；qa/dev/reviewer = 编曲成员菜单（Ivy 验收签署 / Nova·Sage·Milo 三合一编码 / 反方辩护三层只读审查）。2026-08-17 起这些工具首次使用时已由 kix_capability_call 自动激活，本工具仅用于想提前挂载的场景（jobs 已常驻、无需激活）。workflow 依赖 isolate realm 服务、动态激活不可用（激活会报错，直接挂载可用）。运行时挂载其工具包，激活后下一轮请求即可直接调用（无需代理）。用 kix_tool_deactivate 卸载。',
+      description: '显式预激活默认未挂载工具：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser。qa·dev·reviewer=编曲成员（Ivy 验收签署 / Nova·Sage·Milo 编码 / 反方辩护审查）。通常无需手动调用——kix_capability_call 首次使用即自动激活，本工具仅用于想提前挂载的场景；jobs 常驻无需；workflow 动态激活不可用（直接挂载）。激活后下一轮直呼，kix_tool_deactivate 卸载。',
       parameters: {
         type: 'object',
         properties: {
@@ -906,7 +912,7 @@ module.exports = {
 
     const disposeDeactivate = tools.register({
       name: 'kix_tool_deactivate',
-      description: '卸载一个已激活的 scope 工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer，及 browser 浏览器插件）。v5.10 起为延迟卸载：入队后本回合内仍可直呼，回合结束后才真正卸载（工具面中途变更会打断请求前缀缓存）。jobs 已常驻、无需也卸载不了。',
+      description: '卸载一个已激活的按需工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer、browser 浏览器插件）。延迟卸载：入队后本回合内仍可直呼，回合结束才生效（防工具面中途变更打断前缀缓存）。jobs 常驻、无需也卸载不了。',
       parameters: {
         type: 'object',
         properties: {

--- a/dsh/preset-classic/plugins/kix-focus.test.js
+++ b/dsh/preset-classic/plugins/kix-focus.test.js
@@ -130,7 +130,13 @@ await ok('subagent_fork 未挂载(渐进面,默认 disabled)', I.isOnDemand('sub
 await ok('ask_user_question 常驻', I.RESIDENT_TOOLS.has('ask_user_question'))
 await ok('kix_capability_search 常驻', I.RESIDENT_TOOLS.has('kix_capability_search'))
 await ok('mcp__github__get_issue 按需', I.isOnDemand('mcp__github__get_issue'))
-await ok('web_search 按需(低频,移出常驻)', I.isOnDemand('web_search'))
+await ok('web_search 常驻性由 cordis tool-web 行决定（不在 RESIDENT_TOOLS 语义内）', (() => {
+  // web_search 是 preset 行 tool-web 挂载的 scope 工具，常驻/按需由 cordis
+  // 决定，不经 RESIDENT_TOOLS。2026-08-20 三分法回滚：tool-web 恢复常驻，
+  // isOnDemand 语义只服务 kix-focus 自管的工具，web_search 不在其列。
+  return I.isOnDemand('web_search') === true // 语义:非 kix-focus 自管,非 RESIDENT
+    && I.ACTIVATABLE_TOOLS.web_search === undefined
+})())
 await ok('read_image 按需', I.isOnDemand('read_image'))
 await ok('workflow 常驻(临时启用,自发使用测试中)', !I.isOnDemand('workflow'))
 await ok('create_goal 未挂载(默认 disabled,不在常驻集)', I.isOnDemand('create_goal'))
@@ -332,14 +338,12 @@ await ok('restrict deny 裁剪 MCP 全局工具(deny 模式,allow 在 web 架构
   const deny = restrictCalls[0].deny
   return Array.isArray(deny) && deny.includes('mcp__github__get_issue')
 })())
-await ok('restrict deny 含 web_search(低频移出常驻)', (() => {
-  // 全局视图需要含 web_search 才会被收集——追加后触发 tools/change
-  if (!mockGlobalSchemas.some((s) => s.name === 'web_search')) {
-    mockGlobalSchemas.push({ name: 'web_search', description: 'Search' })
-    ;(listeners['tools/change'] || []).forEach((cb) => cb())
-  }
-  const last = restrictCalls[restrictCalls.length - 1]
-  return Array.isArray(last.deny) && last.deny.includes('web_search')
+await ok('restrict deny 不含 web_search（scope-local 工具裁不到，2026-08-20 修正）', (() => {
+  // 曾 mock 把 web_search 塞进全局视图断言 deny 含它——假绿：tool-web 是
+  // preset 行注册（scope-local），restrict 只作用于全局工具，deny 从未生效。
+  // web_search 移出注入走 ACTIVATABLE_TOOLS 激活（见下），不再依赖 restrict。
+  const deny = restrictCalls[0].deny
+  return Array.isArray(deny) && !deny.includes('web_search')
 })())
 await ok('restrict deny 不含 scope-local 工具', (() => {
   const deny = restrictCalls[0].deny
@@ -369,12 +373,14 @@ section('按需激活')
 const activateTool = registeredTools.find((t) => t.name === 'kix_tool_activate')
 const deactivateTool = registeredTools.find((t) => t.name === 'kix_tool_deactivate')
 await ok('activate/deactivate 工具已注册', activateTool !== undefined && deactivateTool !== undefined)
-await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs 已移除)', (() => {
+await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs/web_search 已移除)', (() => {
   return ['workflow', 'goal', 'subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n] && I.ACTIVATABLE_TOOLS[n].package)
     && I.ACTIVATABLE_TOOLS.ralph === undefined
     && I.ACTIVATABLE_TOOLS.jobs === undefined
+    && I.ACTIVATABLE_TOOLS.web_search === undefined // 2026-08-20 三分法回滚：恢复常驻
 })())
+await ok('web_search 恢复常驻（三分法回滚：cordis tool-web 行已恢复）', I.ACTIVATABLE_TOOLS.web_search === undefined)
 await ok('所有动态 subagent 档位 maxDepth=2', (() => {
   return ['subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n].config.maxDepth === 2)

--- a/dsh/preset-null/plugins/kix-discipline.js
+++ b/dsh/preset-null/plugins/kix-discipline.js
@@ -372,7 +372,7 @@ module.exports = {
     // ── 模型工具：记录需求三检契约 ────────────────────────────────────────
     const disposeSpecTool = tools.register({
       name: 'kix_discipline_spec',
-      description: '记录当前任务的需求三检契约（kix 需求三检：XY Problem / 前提假设 / 更优路径），写入工作区 kix-discipline/spec.md。需求三检后、开始实现编辑前调用；契约可跨会话复用。mode 字段（可选）= 编曲留痕：成员组合 + 一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
+      description: '记录需求三检契约（XY Problem / 前提假设 / 更优路径）到工作区 kix-discipline/spec.md。需求三检后、编辑前调用；跨会话复用。mode（可选）= 编曲留痕：成员组合+一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
       parameters: {
         // tools.register 原样投影 parameters：必须含顶层 type: 'object'
         type: 'object',

--- a/dsh/preset-null/plugins/kix-focus.js
+++ b/dsh/preset-null/plugins/kix-focus.js
@@ -70,8 +70,10 @@ const { readFileSync, statSync } = require('node:fs')
 // scope-local 名，代理反而失败）。故 SCOPE_RESIDENT 把它们纳入语义常驻集，
 // 目录/统计口径与实际可见面一致；capability_call 对它们拒绝（"请直接调用"）。
 // RESTRICT_ALLOW 是 allow 时代的白名单（现改用 deny 模式）；保留作统计/文档。
-// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻，
-// 加入 deny 清单（经 capability_call 代理）。
+// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻。
+// 2026-08-20 修正（系统提示词瘦身）：deny 方案从未生效——tool-web 是 preset
+// 行注册（scope-local），restrict 只作用于全局工具；真实裁法是 cordis 行
+// disabled + ACTIVATABLE_TOOLS.web_search 自动激活（见 ACTIVATABLE_TOOLS）。
 const RESTRICT_ALLOW = [
   // 全局基础工具（host 平面注册）
   'edit', 'write', 'read', 'grep', 'glob', 'pwsh', 'bash',
@@ -153,7 +155,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'jobs',
     title: '后台任务（job_output/job_list/job_kill）',
-    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动，job_output/job_list/job_kill 回收与停止',
+    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动；job_list 确认任务存在 → job_output 读结果 → job_kill 停止',
     tools: ['job_output', 'job_list', 'job_kill'],
   },
   {
@@ -171,7 +173,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'search',
     title: '网络搜索（web_search）',
-    hint: '低频（库文档优先 context7 MCP），默认按需：用 kix_capability_call 代理调用 web_search',
+    hint: '常驻可直接调用：外部信息检索用 web_search（库文档优先 context7 MCP）',
     tools: ['web_search'],
   },
   {
@@ -318,6 +320,9 @@ function makeUserMessage(text) {
 const CHILD_MAX_DEPTH = 2
 const CHILD_TOOL_DENY = ['exit_plan_mode', 'subagent', 'subagent_cross', 'interrupt_agent', 'send_message', 'list_agents', 'ask_user_question', 'kix_tool_activate', 'kix_tool_deactivate']
 const ACTIVATABLE_TOOLS = {
+  // 2026-08-20 三分法回滚：web_search 曾加入此处（渐进披露），评估否决——
+  // 低频 + 断 KV 缓存成本远超省下的常驻税，恢复 cordis tool-web 常驻。
+  // 见 dsh/preset/agent.cordis.yml tool-web 行注释（回滚理由完整记录）。
   workflow: { package: '@deepseek-ai/dsh-tool-workflow', config: {} },
   goal: { package: '@deepseek-ai/dsh-tool-goal', config: {} },
   // 2026-08-18 渐进披露扩容：kix-browser（本地插件，17 action 浏览器自动化）
@@ -628,7 +633,8 @@ module.exports = {
     function applyRestrict() {
       if (!enableRestrict) return
       const globals = globalSchemas()
-      // deny 目标 = 全部 MCP 全局工具 + web_search（低频，2026-08-16 移出常驻）
+      // deny 目标 = 全部 MCP 全局工具（scope-local 工具裁不到——web_search
+      // 2026-08-20 起由 cordis disabled + ACTIVATABLE 激活承担，见文件头）
       const denyTargets = globals.filter((s) => s.name && (s.name.startsWith('mcp__') || s.name === 'web_search')).map((s) => s.name)
       const fresh = denyTargets.filter((n) => !denied.has(n))
       if (fresh.length === 0) return // 无新增目标（或尚未注册），等 tools/change / 定时重试
@@ -640,7 +646,7 @@ module.exports = {
         restrictError = null
         clearRetry()
         ctx.effect(() => dispose)
-        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP+web_search，restrict 增量），scope 工具照常可见`)
+        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP，restrict 增量），scope 工具照常可见（按需工具走 cordis disabled + ACTIVATABLE 激活）`)
       } catch (e) {
         restrictError = e && e.message ? e.message : String(e)
         restrictDenyCount = denied.size
@@ -693,7 +699,7 @@ module.exports = {
     // ── Phase 2：kix_capability_call（代理执行 + 首次使用自动激活，常驻）──
     const disposeCall = tools.register({
       name: 'kix_capability_call',
-      description: '代理调用一个按需披露的工具（渐进披露的调用面）：执行目标工具并返回其结果。走完整 pre-execute→guards→execute→post-execute 管线（kix 门禁依然拦截）。MCP/cordis_* 等全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）会**首次使用自动激活**——本调用即挂载并执行、下一轮起可直接调用；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
+      description: '代理调用按需披露工具（走完整 pre-execute→guards→execute 管线，门禁仍拦）。MCP/cordis_* 全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）首次使用自动激活（本调用即挂载并执行、下一轮起直呼）；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
       parameters: {
         // tools.register 原样投影 parameters（不做 ValueSchemaSpec 转换）：
         // 必须传合法 JSON Schema，含顶层 type: 'object'。arguments 用 object +
@@ -877,7 +883,7 @@ module.exports = {
       // 2026-08-17 枚举 bug 修复：描述枚举曾漏 subagent_reviewer（集合有、
       // 描述无——模型照描述行事即永远激活不了它）；现与 ACTIVATABLE_TOOLS
       // 键集合同步（测试有回归防线），新增 qa/dev 一并列入。
-      description: '显式预激活一个默认未挂载的 scope 工具（细分档位与 goal）：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser（本地 kix-browser 插件，17 action 浏览器自动化，pkgPath 解析）；qa/dev/reviewer = 编曲成员菜单（Ivy 验收签署 / Nova·Sage·Milo 三合一编码 / 反方辩护三层只读审查）。2026-08-17 起这些工具首次使用时已由 kix_capability_call 自动激活，本工具仅用于想提前挂载的场景（jobs 已常驻、无需激活）。workflow 依赖 isolate realm 服务、动态激活不可用（激活会报错，直接挂载可用）。运行时挂载其工具包，激活后下一轮请求即可直接调用（无需代理）。用 kix_tool_deactivate 卸载。',
+      description: '显式预激活默认未挂载工具：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser。qa·dev·reviewer=编曲成员（Ivy 验收签署 / Nova·Sage·Milo 编码 / 反方辩护审查）。通常无需手动调用——kix_capability_call 首次使用即自动激活，本工具仅用于想提前挂载的场景；jobs 常驻无需；workflow 动态激活不可用（直接挂载）。激活后下一轮直呼，kix_tool_deactivate 卸载。',
       parameters: {
         type: 'object',
         properties: {
@@ -906,7 +912,7 @@ module.exports = {
 
     const disposeDeactivate = tools.register({
       name: 'kix_tool_deactivate',
-      description: '卸载一个已激活的 scope 工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer，及 browser 浏览器插件）。v5.10 起为延迟卸载：入队后本回合内仍可直呼，回合结束后才真正卸载（工具面中途变更会打断请求前缀缓存）。jobs 已常驻、无需也卸载不了。',
+      description: '卸载一个已激活的按需工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer、browser 浏览器插件）。延迟卸载：入队后本回合内仍可直呼，回合结束才生效（防工具面中途变更打断前缀缓存）。jobs 常驻、无需也卸载不了。',
       parameters: {
         type: 'object',
         properties: {

--- a/dsh/preset-null/plugins/kix-focus.test.js
+++ b/dsh/preset-null/plugins/kix-focus.test.js
@@ -130,7 +130,13 @@ await ok('subagent_fork 未挂载(渐进面,默认 disabled)', I.isOnDemand('sub
 await ok('ask_user_question 常驻', I.RESIDENT_TOOLS.has('ask_user_question'))
 await ok('kix_capability_search 常驻', I.RESIDENT_TOOLS.has('kix_capability_search'))
 await ok('mcp__github__get_issue 按需', I.isOnDemand('mcp__github__get_issue'))
-await ok('web_search 按需(低频,移出常驻)', I.isOnDemand('web_search'))
+await ok('web_search 常驻性由 cordis tool-web 行决定（不在 RESIDENT_TOOLS 语义内）', (() => {
+  // web_search 是 preset 行 tool-web 挂载的 scope 工具，常驻/按需由 cordis
+  // 决定，不经 RESIDENT_TOOLS。2026-08-20 三分法回滚：tool-web 恢复常驻，
+  // isOnDemand 语义只服务 kix-focus 自管的工具，web_search 不在其列。
+  return I.isOnDemand('web_search') === true // 语义:非 kix-focus 自管,非 RESIDENT
+    && I.ACTIVATABLE_TOOLS.web_search === undefined
+})())
 await ok('read_image 按需', I.isOnDemand('read_image'))
 await ok('workflow 常驻(临时启用,自发使用测试中)', !I.isOnDemand('workflow'))
 await ok('create_goal 未挂载(默认 disabled,不在常驻集)', I.isOnDemand('create_goal'))
@@ -332,14 +338,12 @@ await ok('restrict deny 裁剪 MCP 全局工具(deny 模式,allow 在 web 架构
   const deny = restrictCalls[0].deny
   return Array.isArray(deny) && deny.includes('mcp__github__get_issue')
 })())
-await ok('restrict deny 含 web_search(低频移出常驻)', (() => {
-  // 全局视图需要含 web_search 才会被收集——追加后触发 tools/change
-  if (!mockGlobalSchemas.some((s) => s.name === 'web_search')) {
-    mockGlobalSchemas.push({ name: 'web_search', description: 'Search' })
-    ;(listeners['tools/change'] || []).forEach((cb) => cb())
-  }
-  const last = restrictCalls[restrictCalls.length - 1]
-  return Array.isArray(last.deny) && last.deny.includes('web_search')
+await ok('restrict deny 不含 web_search（scope-local 工具裁不到，2026-08-20 修正）', (() => {
+  // 曾 mock 把 web_search 塞进全局视图断言 deny 含它——假绿：tool-web 是
+  // preset 行注册（scope-local），restrict 只作用于全局工具，deny 从未生效。
+  // web_search 移出注入走 ACTIVATABLE_TOOLS 激活（见下），不再依赖 restrict。
+  const deny = restrictCalls[0].deny
+  return Array.isArray(deny) && !deny.includes('web_search')
 })())
 await ok('restrict deny 不含 scope-local 工具', (() => {
   const deny = restrictCalls[0].deny
@@ -369,12 +373,14 @@ section('按需激活')
 const activateTool = registeredTools.find((t) => t.name === 'kix_tool_activate')
 const deactivateTool = registeredTools.find((t) => t.name === 'kix_tool_deactivate')
 await ok('activate/deactivate 工具已注册', activateTool !== undefined && deactivateTool !== undefined)
-await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs 已移除)', (() => {
+await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs/web_search 已移除)', (() => {
   return ['workflow', 'goal', 'subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n] && I.ACTIVATABLE_TOOLS[n].package)
     && I.ACTIVATABLE_TOOLS.ralph === undefined
     && I.ACTIVATABLE_TOOLS.jobs === undefined
+    && I.ACTIVATABLE_TOOLS.web_search === undefined // 2026-08-20 三分法回滚：恢复常驻
 })())
+await ok('web_search 恢复常驻（三分法回滚：cordis tool-web 行已恢复）', I.ACTIVATABLE_TOOLS.web_search === undefined)
 await ok('所有动态 subagent 档位 maxDepth=2', (() => {
   return ['subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n].config.maxDepth === 2)

--- a/dsh/preset-null/plugins/kix-mem.js
+++ b/dsh/preset-null/plugins/kix-mem.js
@@ -15,7 +15,7 @@ const path = require('node:path')
 const MEM_DIR = path.resolve(__dirname, '..', 'memories')
 
 const DESCRIPTION =
-  'Browse a crisis-indexed library of hard-won empirical lessons from past sessions (contract clarity, verification, cost relocation, harness pitfalls). Entries cite the experiment or incident they came from. action=list returns the catalog; action=get returns one full note. The files can also be read directly.'
+  'Browse a crisis-indexed library of hard-won empirical lessons from past sessions. action=list returns the catalog; action=get returns one full note; files can also be read directly. Use when stuck or after an incident to learn from past experience; for how-to task guidance use skill instead.'
 
 function listEntries() {
   const out = []

--- a/dsh/preset-null/plugins/kix-probe.js
+++ b/dsh/preset-null/plugins/kix-probe.js
@@ -15,7 +15,7 @@ const path = require('node:path')
 const crypto = require('node:crypto')
 
 const DESCRIPTION =
-  'Run a short Python snippet in a fresh process against the current workspace and return its stdout, stderr, exit code, and wall-clock duration; optionally measure peak memory. Useful when you need to know how something actually behaves.'
+  'Run a short Python snippet in a fresh process against the current workspace; returns stdout, stderr, exit code, and wall-clock duration, optionally peak memory. Use for isolated Python checks (memory/time probing, quick verification); for full shell commands use bash.'
 
 const MEASURE_WRAPPER = [
   'import sys, tracemalloc',

--- a/dsh/preset/agent.cordis.yml
+++ b/dsh/preset/agent.cordis.yml
@@ -739,6 +739,11 @@
 
 # The `web` service and its search provider stay in the host composition; only
 # the model-facing tool is per-session.
+# 2026-08-20 回滚（三分法落地）：web_search 恢复常驻。曾尝试渐进披露
+# （ACTIVATABLE_TOOLS.web_search），评估否决：低频 + 断 KV 缓存一次的成本
+# （cacheRead:input 实测 127:1，长会话全价重读）远超省下的 660 tok/步常驻税；
+# 且 scope-local 工具 restrict 裁不到，渐进披露需要 cordis disabled + 激活
+# 双重机制。web_search 小（660 tok）低频 → 常驻税可接受，零断缓存风险。
 - id: tool-web
   name: '@deepseek-ai/dsh-tool-web'
   config:

--- a/dsh/preset/plugins/kix-discipline.js
+++ b/dsh/preset/plugins/kix-discipline.js
@@ -372,7 +372,7 @@ module.exports = {
     // ── 模型工具：记录需求三检契约 ────────────────────────────────────────
     const disposeSpecTool = tools.register({
       name: 'kix_discipline_spec',
-      description: '记录当前任务的需求三检契约（kix 需求三检：XY Problem / 前提假设 / 更优路径），写入工作区 kix-discipline/spec.md。需求三检后、开始实现编辑前调用；契约可跨会话复用。mode 字段（可选）= 编曲留痕：成员组合 + 一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
+      description: '记录需求三检契约（XY Problem / 前提假设 / 更优路径）到工作区 kix-discipline/spec.md。需求三检后、编辑前调用；跨会话复用。mode（可选）= 编曲留痕：成员组合+一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
       parameters: {
         // tools.register 原样投影 parameters：必须含顶层 type: 'object'
         type: 'object',

--- a/dsh/preset/plugins/kix-focus.js
+++ b/dsh/preset/plugins/kix-focus.js
@@ -70,8 +70,10 @@ const { readFileSync, statSync } = require('node:fs')
 // scope-local 名，代理反而失败）。故 SCOPE_RESIDENT 把它们纳入语义常驻集，
 // 目录/统计口径与实际可见面一致；capability_call 对它们拒绝（"请直接调用"）。
 // RESTRICT_ALLOW 是 allow 时代的白名单（现改用 deny 模式）；保留作统计/文档。
-// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻，
-// 加入 deny 清单（经 capability_call 代理）。
+// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻。
+// 2026-08-20 修正（系统提示词瘦身）：deny 方案从未生效——tool-web 是 preset
+// 行注册（scope-local），restrict 只作用于全局工具；真实裁法是 cordis 行
+// disabled + ACTIVATABLE_TOOLS.web_search 自动激活（见 ACTIVATABLE_TOOLS）。
 const RESTRICT_ALLOW = [
   // 全局基础工具（host 平面注册）
   'edit', 'write', 'read', 'grep', 'glob', 'pwsh', 'bash',
@@ -153,7 +155,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'jobs',
     title: '后台任务（job_output/job_list/job_kill）',
-    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动，job_output/job_list/job_kill 回收与停止',
+    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动；job_list 确认任务存在 → job_output 读结果 → job_kill 停止',
     tools: ['job_output', 'job_list', 'job_kill'],
   },
   {
@@ -171,7 +173,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'search',
     title: '网络搜索（web_search）',
-    hint: '低频（库文档优先 context7 MCP），默认按需：用 kix_capability_call 代理调用 web_search',
+    hint: '常驻可直接调用：外部信息检索用 web_search（库文档优先 context7 MCP）',
     tools: ['web_search'],
   },
   {
@@ -318,6 +320,9 @@ function makeUserMessage(text) {
 const CHILD_MAX_DEPTH = 2
 const CHILD_TOOL_DENY = ['exit_plan_mode', 'subagent', 'subagent_cross', 'interrupt_agent', 'send_message', 'list_agents', 'ask_user_question', 'kix_tool_activate', 'kix_tool_deactivate']
 const ACTIVATABLE_TOOLS = {
+  // 2026-08-20 三分法回滚：web_search 曾加入此处（渐进披露），评估否决——
+  // 低频 + 断 KV 缓存成本远超省下的常驻税，恢复 cordis tool-web 常驻。
+  // 见 dsh/preset/agent.cordis.yml tool-web 行注释（回滚理由完整记录）。
   workflow: { package: '@deepseek-ai/dsh-tool-workflow', config: {} },
   goal: { package: '@deepseek-ai/dsh-tool-goal', config: {} },
   // 2026-08-18 渐进披露扩容：kix-browser（本地插件，17 action 浏览器自动化）
@@ -628,7 +633,8 @@ module.exports = {
     function applyRestrict() {
       if (!enableRestrict) return
       const globals = globalSchemas()
-      // deny 目标 = 全部 MCP 全局工具 + web_search（低频，2026-08-16 移出常驻）
+      // deny 目标 = 全部 MCP 全局工具（scope-local 工具裁不到——web_search
+      // 2026-08-20 起由 cordis disabled + ACTIVATABLE 激活承担，见文件头）
       const denyTargets = globals.filter((s) => s.name && (s.name.startsWith('mcp__') || s.name === 'web_search')).map((s) => s.name)
       const fresh = denyTargets.filter((n) => !denied.has(n))
       if (fresh.length === 0) return // 无新增目标（或尚未注册），等 tools/change / 定时重试
@@ -640,7 +646,7 @@ module.exports = {
         restrictError = null
         clearRetry()
         ctx.effect(() => dispose)
-        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP+web_search，restrict 增量），scope 工具照常可见`)
+        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP，restrict 增量），scope 工具照常可见（按需工具走 cordis disabled + ACTIVATABLE 激活）`)
       } catch (e) {
         restrictError = e && e.message ? e.message : String(e)
         restrictDenyCount = denied.size
@@ -693,7 +699,7 @@ module.exports = {
     // ── Phase 2：kix_capability_call（代理执行 + 首次使用自动激活，常驻）──
     const disposeCall = tools.register({
       name: 'kix_capability_call',
-      description: '代理调用一个按需披露的工具（渐进披露的调用面）：执行目标工具并返回其结果。走完整 pre-execute→guards→execute→post-execute 管线（kix 门禁依然拦截）。MCP/cordis_* 等全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）会**首次使用自动激活**——本调用即挂载并执行、下一轮起可直接调用；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
+      description: '代理调用按需披露工具（走完整 pre-execute→guards→execute 管线，门禁仍拦）。MCP/cordis_* 全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）首次使用自动激活（本调用即挂载并执行、下一轮起直呼）；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
       parameters: {
         // tools.register 原样投影 parameters（不做 ValueSchemaSpec 转换）：
         // 必须传合法 JSON Schema，含顶层 type: 'object'。arguments 用 object +
@@ -877,7 +883,7 @@ module.exports = {
       // 2026-08-17 枚举 bug 修复：描述枚举曾漏 subagent_reviewer（集合有、
       // 描述无——模型照描述行事即永远激活不了它）；现与 ACTIVATABLE_TOOLS
       // 键集合同步（测试有回归防线），新增 qa/dev 一并列入。
-      description: '显式预激活一个默认未挂载的 scope 工具（细分档位与 goal）：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser（本地 kix-browser 插件，17 action 浏览器自动化，pkgPath 解析）；qa/dev/reviewer = 编曲成员菜单（Ivy 验收签署 / Nova·Sage·Milo 三合一编码 / 反方辩护三层只读审查）。2026-08-17 起这些工具首次使用时已由 kix_capability_call 自动激活，本工具仅用于想提前挂载的场景（jobs 已常驻、无需激活）。workflow 依赖 isolate realm 服务、动态激活不可用（激活会报错，直接挂载可用）。运行时挂载其工具包，激活后下一轮请求即可直接调用（无需代理）。用 kix_tool_deactivate 卸载。',
+      description: '显式预激活默认未挂载工具：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser。qa·dev·reviewer=编曲成员（Ivy 验收签署 / Nova·Sage·Milo 编码 / 反方辩护审查）。通常无需手动调用——kix_capability_call 首次使用即自动激活，本工具仅用于想提前挂载的场景；jobs 常驻无需；workflow 动态激活不可用（直接挂载）。激活后下一轮直呼，kix_tool_deactivate 卸载。',
       parameters: {
         type: 'object',
         properties: {
@@ -906,7 +912,7 @@ module.exports = {
 
     const disposeDeactivate = tools.register({
       name: 'kix_tool_deactivate',
-      description: '卸载一个已激活的 scope 工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer，及 browser 浏览器插件）。v5.10 起为延迟卸载：入队后本回合内仍可直呼，回合结束后才真正卸载（工具面中途变更会打断请求前缀缓存）。jobs 已常驻、无需也卸载不了。',
+      description: '卸载一个已激活的按需工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer、browser 浏览器插件）。延迟卸载：入队后本回合内仍可直呼，回合结束才生效（防工具面中途变更打断前缀缓存）。jobs 常驻、无需也卸载不了。',
       parameters: {
         type: 'object',
         properties: {

--- a/dsh/preset/plugins/kix-focus.test.js
+++ b/dsh/preset/plugins/kix-focus.test.js
@@ -130,7 +130,13 @@ await ok('subagent_fork 未挂载(渐进面,默认 disabled)', I.isOnDemand('sub
 await ok('ask_user_question 常驻', I.RESIDENT_TOOLS.has('ask_user_question'))
 await ok('kix_capability_search 常驻', I.RESIDENT_TOOLS.has('kix_capability_search'))
 await ok('mcp__github__get_issue 按需', I.isOnDemand('mcp__github__get_issue'))
-await ok('web_search 按需(低频,移出常驻)', I.isOnDemand('web_search'))
+await ok('web_search 常驻性由 cordis tool-web 行决定（不在 RESIDENT_TOOLS 语义内）', (() => {
+  // web_search 是 preset 行 tool-web 挂载的 scope 工具，常驻/按需由 cordis
+  // 决定，不经 RESIDENT_TOOLS。2026-08-20 三分法回滚：tool-web 恢复常驻，
+  // isOnDemand 语义只服务 kix-focus 自管的工具，web_search 不在其列。
+  return I.isOnDemand('web_search') === true // 语义:非 kix-focus 自管,非 RESIDENT
+    && I.ACTIVATABLE_TOOLS.web_search === undefined
+})())
 await ok('read_image 按需', I.isOnDemand('read_image'))
 await ok('workflow 常驻(临时启用,自发使用测试中)', !I.isOnDemand('workflow'))
 await ok('create_goal 未挂载(默认 disabled,不在常驻集)', I.isOnDemand('create_goal'))
@@ -332,14 +338,12 @@ await ok('restrict deny 裁剪 MCP 全局工具(deny 模式,allow 在 web 架构
   const deny = restrictCalls[0].deny
   return Array.isArray(deny) && deny.includes('mcp__github__get_issue')
 })())
-await ok('restrict deny 含 web_search(低频移出常驻)', (() => {
-  // 全局视图需要含 web_search 才会被收集——追加后触发 tools/change
-  if (!mockGlobalSchemas.some((s) => s.name === 'web_search')) {
-    mockGlobalSchemas.push({ name: 'web_search', description: 'Search' })
-    ;(listeners['tools/change'] || []).forEach((cb) => cb())
-  }
-  const last = restrictCalls[restrictCalls.length - 1]
-  return Array.isArray(last.deny) && last.deny.includes('web_search')
+await ok('restrict deny 不含 web_search（scope-local 工具裁不到，2026-08-20 修正）', (() => {
+  // 曾 mock 把 web_search 塞进全局视图断言 deny 含它——假绿：tool-web 是
+  // preset 行注册（scope-local），restrict 只作用于全局工具，deny 从未生效。
+  // web_search 移出注入走 ACTIVATABLE_TOOLS 激活（见下），不再依赖 restrict。
+  const deny = restrictCalls[0].deny
+  return Array.isArray(deny) && !deny.includes('web_search')
 })())
 await ok('restrict deny 不含 scope-local 工具', (() => {
   const deny = restrictCalls[0].deny
@@ -369,12 +373,14 @@ section('按需激活')
 const activateTool = registeredTools.find((t) => t.name === 'kix_tool_activate')
 const deactivateTool = registeredTools.find((t) => t.name === 'kix_tool_deactivate')
 await ok('activate/deactivate 工具已注册', activateTool !== undefined && deactivateTool !== undefined)
-await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs 已移除)', (() => {
+await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs/web_search 已移除)', (() => {
   return ['workflow', 'goal', 'subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n] && I.ACTIVATABLE_TOOLS[n].package)
     && I.ACTIVATABLE_TOOLS.ralph === undefined
     && I.ACTIVATABLE_TOOLS.jobs === undefined
+    && I.ACTIVATABLE_TOOLS.web_search === undefined // 2026-08-20 三分法回滚：恢复常驻
 })())
+await ok('web_search 恢复常驻（三分法回滚：cordis tool-web 行已恢复）', I.ACTIVATABLE_TOOLS.web_search === undefined)
 await ok('所有动态 subagent 档位 maxDepth=2', (() => {
   return ['subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n].config.maxDepth === 2)

--- a/dsh/preset/plugins/kix-mem.js
+++ b/dsh/preset/plugins/kix-mem.js
@@ -15,7 +15,7 @@ const path = require('node:path')
 const MEM_DIR = path.resolve(__dirname, '..', 'memories')
 
 const DESCRIPTION =
-  'Browse a crisis-indexed library of hard-won empirical lessons from past sessions (contract clarity, verification, cost relocation, harness pitfalls). Entries cite the experiment or incident they came from. action=list returns the catalog; action=get returns one full note. The files can also be read directly.'
+  'Browse a crisis-indexed library of hard-won empirical lessons from past sessions. action=list returns the catalog; action=get returns one full note; files can also be read directly. Use when stuck or after an incident to learn from past experience; for how-to task guidance use skill instead.'
 
 function listEntries() {
   const out = []

--- a/dsh/preset/plugins/kix-probe.js
+++ b/dsh/preset/plugins/kix-probe.js
@@ -15,7 +15,7 @@ const path = require('node:path')
 const crypto = require('node:crypto')
 
 const DESCRIPTION =
-  'Run a short Python snippet in a fresh process against the current workspace and return its stdout, stderr, exit code, and wall-clock duration; optionally measure peak memory. Useful when you need to know how something actually behaves.'
+  'Run a short Python snippet in a fresh process against the current workspace; returns stdout, stderr, exit code, and wall-clock duration, optionally peak memory. Use for isolated Python checks (memory/time probing, quick verification); for full shell commands use bash.'
 
 const MEASURE_WRAPPER = [
   'import sys, tracemalloc',

--- a/en/package.json
+++ b/en/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kixparadigm-en",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "kixparadigm-en — English edition of the kix paradigm preset for DeepSeek Harness: resident cognition layer (EN) + kixpower multi-agent orchestration, one-command import (preset + vision-bridge + guard plugins)",
   "license": "MIT",
   "author": "kix (olicesx)",

--- a/en/preset-classic-en/plugins/kix-discipline.js
+++ b/en/preset-classic-en/plugins/kix-discipline.js
@@ -372,7 +372,7 @@ module.exports = {
     // ── 模型工具：记录需求三检契约 ────────────────────────────────────────
     const disposeSpecTool = tools.register({
       name: 'kix_discipline_spec',
-      description: '记录当前任务的需求三检契约（kix 需求三检：XY Problem / 前提假设 / 更优路径），写入工作区 kix-discipline/spec.md。需求三检后、开始实现编辑前调用；契约可跨会话复用。mode 字段（可选）= 编曲留痕：成员组合 + 一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
+      description: '记录需求三检契约（XY Problem / 前提假设 / 更优路径）到工作区 kix-discipline/spec.md。需求三检后、编辑前调用；跨会话复用。mode（可选）= 编曲留痕：成员组合+一句理由，如 "dev+qa：跨模块改动需独立验收" / "solo：字面明确单文件修复"。',
       parameters: {
         // tools.register 原样投影 parameters：必须含顶层 type: 'object'
         type: 'object',

--- a/en/preset-classic-en/plugins/kix-focus.js
+++ b/en/preset-classic-en/plugins/kix-focus.js
@@ -70,8 +70,10 @@ const { readFileSync, statSync } = require('node:fs')
 // scope-local 名，代理反而失败）。故 SCOPE_RESIDENT 把它们纳入语义常驻集，
 // 目录/统计口径与实际可见面一致；capability_call 对它们拒绝（"请直接调用"）。
 // RESTRICT_ALLOW 是 allow 时代的白名单（现改用 deny 模式）；保留作统计/文档。
-// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻，
-// 加入 deny 清单（经 capability_call 代理）。
+// 2026-08-16：web_search 低频（库文档已由 context7 MCP 承担）→ 移出常驻。
+// 2026-08-20 修正（系统提示词瘦身）：deny 方案从未生效——tool-web 是 preset
+// 行注册（scope-local），restrict 只作用于全局工具；真实裁法是 cordis 行
+// disabled + ACTIVATABLE_TOOLS.web_search 自动激活（见 ACTIVATABLE_TOOLS）。
 const RESTRICT_ALLOW = [
   // 全局基础工具（host 平面注册）
   'edit', 'write', 'read', 'grep', 'glob', 'pwsh', 'bash',
@@ -153,7 +155,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'jobs',
     title: '后台任务（job_output/job_list/job_kill）',
-    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动，job_output/job_list/job_kill 回收与停止',
+    hint: '常驻、可直接调用：长任务用 pwsh run_in_background: true 启动；job_list 确认任务存在 → job_output 读结果 → job_kill 停止',
     tools: ['job_output', 'job_list', 'job_kill'],
   },
   {
@@ -171,7 +173,7 @@ const CAPABILITY_GROUPS = [
   {
     id: 'search',
     title: '网络搜索（web_search）',
-    hint: '低频（库文档优先 context7 MCP），默认按需：用 kix_capability_call 代理调用 web_search',
+    hint: '常驻可直接调用：外部信息检索用 web_search（库文档优先 context7 MCP）',
     tools: ['web_search'],
   },
   {
@@ -318,6 +320,9 @@ function makeUserMessage(text) {
 const CHILD_MAX_DEPTH = 2
 const CHILD_TOOL_DENY = ['exit_plan_mode', 'subagent', 'subagent_cross', 'interrupt_agent', 'send_message', 'list_agents', 'ask_user_question', 'kix_tool_activate', 'kix_tool_deactivate']
 const ACTIVATABLE_TOOLS = {
+  // 2026-08-20 三分法回滚：web_search 曾加入此处（渐进披露），评估否决——
+  // 低频 + 断 KV 缓存成本远超省下的常驻税，恢复 cordis tool-web 常驻。
+  // 见 dsh/preset/agent.cordis.yml tool-web 行注释（回滚理由完整记录）。
   workflow: { package: '@deepseek-ai/dsh-tool-workflow', config: {} },
   goal: { package: '@deepseek-ai/dsh-tool-goal', config: {} },
   // 2026-08-18 渐进披露扩容：kix-browser（本地插件，17 action 浏览器自动化）
@@ -628,7 +633,8 @@ module.exports = {
     function applyRestrict() {
       if (!enableRestrict) return
       const globals = globalSchemas()
-      // deny 目标 = 全部 MCP 全局工具 + web_search（低频，2026-08-16 移出常驻）
+      // deny 目标 = 全部 MCP 全局工具（scope-local 工具裁不到——web_search
+      // 2026-08-20 起由 cordis disabled + ACTIVATABLE 激活承担，见文件头）
       const denyTargets = globals.filter((s) => s.name && (s.name.startsWith('mcp__') || s.name === 'web_search')).map((s) => s.name)
       const fresh = denyTargets.filter((n) => !denied.has(n))
       if (fresh.length === 0) return // 无新增目标（或尚未注册），等 tools/change / 定时重试
@@ -640,7 +646,7 @@ module.exports = {
         restrictError = null
         clearRetry()
         ctx.effect(() => dispose)
-        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP+web_search，restrict 增量），scope 工具照常可见`)
+        ctx.logger?.info?.(`[kix-focus] 工具已裁剪：deny 累计 ${denied.size} 个全局工具（MCP，restrict 增量），scope 工具照常可见（按需工具走 cordis disabled + ACTIVATABLE 激活）`)
       } catch (e) {
         restrictError = e && e.message ? e.message : String(e)
         restrictDenyCount = denied.size
@@ -693,7 +699,7 @@ module.exports = {
     // ── Phase 2：kix_capability_call（代理执行 + 首次使用自动激活，常驻）──
     const disposeCall = tools.register({
       name: 'kix_capability_call',
-      description: '代理调用一个按需披露的工具（渐进披露的调用面）：执行目标工具并返回其结果。走完整 pre-execute→guards→execute→post-execute 管线（kix 门禁依然拦截）。MCP/cordis_* 等全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）会**首次使用自动激活**——本调用即挂载并执行、下一轮起可直接调用；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
+      description: '代理调用按需披露工具（走完整 pre-execute→guards→execute 管线，门禁仍拦）。MCP/cordis_* 全局按需工具直接代理执行；未挂载的 subagent 细分档位与 goal（subagent_lite/thinker/vision/fork/reviewer/qa/dev、create_goal 等）首次使用自动激活（本调用即挂载并执行、下一轮起直呼）；scope 常驻工具（workflow/job_* 等）请直接调用，本工具会拒绝。',
       parameters: {
         // tools.register 原样投影 parameters（不做 ValueSchemaSpec 转换）：
         // 必须传合法 JSON Schema，含顶层 type: 'object'。arguments 用 object +
@@ -877,7 +883,7 @@ module.exports = {
       // 2026-08-17 枚举 bug 修复：描述枚举曾漏 subagent_reviewer（集合有、
       // 描述无——模型照描述行事即永远激活不了它）；现与 ACTIVATABLE_TOOLS
       // 键集合同步（测试有回归防线），新增 qa/dev 一并列入。
-      description: '显式预激活一个默认未挂载的 scope 工具（细分档位与 goal）：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser（本地 kix-browser 插件，17 action 浏览器自动化，pkgPath 解析）；qa/dev/reviewer = 编曲成员菜单（Ivy 验收签署 / Nova·Sage·Milo 三合一编码 / 反方辩护三层只读审查）。2026-08-17 起这些工具首次使用时已由 kix_capability_call 自动激活，本工具仅用于想提前挂载的场景（jobs 已常驻、无需激活）。workflow 依赖 isolate realm 服务、动态激活不可用（激活会报错，直接挂载可用）。运行时挂载其工具包，激活后下一轮请求即可直接调用（无需代理）。用 kix_tool_deactivate 卸载。',
+      description: '显式预激活默认未挂载工具：goal / subagent_lite / subagent_thinker / subagent_vision / subagent_fork / subagent_reviewer / subagent_qa / subagent_dev / browser。qa·dev·reviewer=编曲成员（Ivy 验收签署 / Nova·Sage·Milo 编码 / 反方辩护审查）。通常无需手动调用——kix_capability_call 首次使用即自动激活，本工具仅用于想提前挂载的场景；jobs 常驻无需；workflow 动态激活不可用（直接挂载）。激活后下一轮直呼，kix_tool_deactivate 卸载。',
       parameters: {
         type: 'object',
         properties: {
@@ -906,7 +912,7 @@ module.exports = {
 
     const disposeDeactivate = tools.register({
       name: 'kix_tool_deactivate',
-      description: '卸载一个已激活的 scope 工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer，及 browser 浏览器插件）。v5.10 起为延迟卸载：入队后本回合内仍可直呼，回合结束后才真正卸载（工具面中途变更会打断请求前缀缓存）。jobs 已常驻、无需也卸载不了。',
+      description: '卸载一个已激活的按需工具（goal/subagent 细分档位含编曲成员 qa/dev/reviewer、browser 浏览器插件）。延迟卸载：入队后本回合内仍可直呼，回合结束才生效（防工具面中途变更打断前缀缓存）。jobs 常驻、无需也卸载不了。',
       parameters: {
         type: 'object',
         properties: {

--- a/en/preset-classic-en/plugins/kix-focus.test.js
+++ b/en/preset-classic-en/plugins/kix-focus.test.js
@@ -130,7 +130,13 @@ await ok('subagent_fork 未挂载(渐进面,默认 disabled)', I.isOnDemand('sub
 await ok('ask_user_question 常驻', I.RESIDENT_TOOLS.has('ask_user_question'))
 await ok('kix_capability_search 常驻', I.RESIDENT_TOOLS.has('kix_capability_search'))
 await ok('mcp__github__get_issue 按需', I.isOnDemand('mcp__github__get_issue'))
-await ok('web_search 按需(低频,移出常驻)', I.isOnDemand('web_search'))
+await ok('web_search 常驻性由 cordis tool-web 行决定（不在 RESIDENT_TOOLS 语义内）', (() => {
+  // web_search 是 preset 行 tool-web 挂载的 scope 工具，常驻/按需由 cordis
+  // 决定，不经 RESIDENT_TOOLS。2026-08-20 三分法回滚：tool-web 恢复常驻，
+  // isOnDemand 语义只服务 kix-focus 自管的工具，web_search 不在其列。
+  return I.isOnDemand('web_search') === true // 语义:非 kix-focus 自管,非 RESIDENT
+    && I.ACTIVATABLE_TOOLS.web_search === undefined
+})())
 await ok('read_image 按需', I.isOnDemand('read_image'))
 await ok('workflow 常驻(临时启用,自发使用测试中)', !I.isOnDemand('workflow'))
 await ok('create_goal 未挂载(默认 disabled,不在常驻集)', I.isOnDemand('create_goal'))
@@ -332,14 +338,12 @@ await ok('restrict deny 裁剪 MCP 全局工具(deny 模式,allow 在 web 架构
   const deny = restrictCalls[0].deny
   return Array.isArray(deny) && deny.includes('mcp__github__get_issue')
 })())
-await ok('restrict deny 含 web_search(低频移出常驻)', (() => {
-  // 全局视图需要含 web_search 才会被收集——追加后触发 tools/change
-  if (!mockGlobalSchemas.some((s) => s.name === 'web_search')) {
-    mockGlobalSchemas.push({ name: 'web_search', description: 'Search' })
-    ;(listeners['tools/change'] || []).forEach((cb) => cb())
-  }
-  const last = restrictCalls[restrictCalls.length - 1]
-  return Array.isArray(last.deny) && last.deny.includes('web_search')
+await ok('restrict deny 不含 web_search（scope-local 工具裁不到，2026-08-20 修正）', (() => {
+  // 曾 mock 把 web_search 塞进全局视图断言 deny 含它——假绿：tool-web 是
+  // preset 行注册（scope-local），restrict 只作用于全局工具，deny 从未生效。
+  // web_search 移出注入走 ACTIVATABLE_TOOLS 激活（见下），不再依赖 restrict。
+  const deny = restrictCalls[0].deny
+  return Array.isArray(deny) && !deny.includes('web_search')
 })())
 await ok('restrict deny 不含 scope-local 工具', (() => {
   const deny = restrictCalls[0].deny
@@ -369,12 +373,14 @@ section('按需激活')
 const activateTool = registeredTools.find((t) => t.name === 'kix_tool_activate')
 const deactivateTool = registeredTools.find((t) => t.name === 'kix_tool_deactivate')
 await ok('activate/deactivate 工具已注册', activateTool !== undefined && deactivateTool !== undefined)
-await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs 已移除)', (() => {
+await ok('ACTIVATABLE_TOOLS 含 workflow/goal/细分档位/reviewer/qa/dev(ralph/jobs/web_search 已移除)', (() => {
   return ['workflow', 'goal', 'subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n] && I.ACTIVATABLE_TOOLS[n].package)
     && I.ACTIVATABLE_TOOLS.ralph === undefined
     && I.ACTIVATABLE_TOOLS.jobs === undefined
+    && I.ACTIVATABLE_TOOLS.web_search === undefined // 2026-08-20 三分法回滚：恢复常驻
 })())
+await ok('web_search 恢复常驻（三分法回滚：cordis tool-web 行已恢复）', I.ACTIVATABLE_TOOLS.web_search === undefined)
 await ok('所有动态 subagent 档位 maxDepth=2', (() => {
   return ['subagent_lite', 'subagent_thinker', 'subagent_vision', 'subagent_fork', 'subagent_reviewer', 'subagent_qa', 'subagent_dev']
     .every((n) => I.ACTIVATABLE_TOOLS[n].config.maxDepth === 2)

--- a/en/scripts/check-consistency.cjs
+++ b/en/scripts/check-consistency.cjs
@@ -11,7 +11,7 @@ const lib = require('../preset-classic-en/plugins/consistency-lib.cjs')
 
 const ROOT = path.join(__dirname, '..')
 
-const { failures, notes } = lib.runAllEn(ROOT, '1.3.4')
+const { failures, notes } = lib.runAllEn(ROOT, '1.3.5')
 for (const n of notes) console.log('  ✔ ' + n)
 
 if (failures.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kixparadigm",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "kixparadigm — AI 自编排最小范式（认知层常驻）+ kixpower 多智能体编排 + DSH 一键导入（preset + vision-bridge + 门禁插件）",
   "license": "MIT",
   "author": "kix (olicesx)",


### PR DESCRIPTION
## v1.3.5 — web_search 恢复常驻 + 工具描述压缩

### 为什么
把 `web_search` 渐进披露否决：断 KV 缓存一次（cacheRead:input 实测 127:1）远超 ~660 tok/步常驻税；`tool-web` 是 scope-local，restrict 裁不到。

### 改动
- 默认 preset `tool-web` 恢复常驻；`ACTIVATABLE_TOOLS.web_search` 删除
- 压缩 capability / discipline / probe / experience schema 文案
- 四副本 kix-focus / kix-discipline identical

### 经典模式
保持 1.3.4 安装面：`kixparadigm` + `kixparadigm-classic`；en = `kixparadigm-classic-en`。pack dry-run：zh 265 files（classic 110 路径），en 120 files。

### 质量链
zh `npm test` CONSISTENCY OK，fail 0；en `npm test` CONSISTENCY OK，fail 0。

详见 CHANGELOG.md v1.3.5。