### PR TITLE
release: 1.3.14 - DSH 0.1.2 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.3.14（2026-09-09）DSH 0.1.2 对接：web_fetch 打开、webhook→会话桥、原生模型选型留档
+
+- **`web_fetch` 打开（`tool-web.config.fetch: true`）**：DSH 0.1.2 起宿主默认挂载 SSRF 加固的 `dsh-web-fetch-http` 提供方（公网地址校验 / 连接固定 / 同源重定向 / 字节上限），0.1.1 时代关闭的理由（无提供方 → SSRF 防护后移、目标由模型选）已消失。给 kix 的「外部语义密集 claim 至少一条可重放物证通道」补上原文取证面。实测：0.1.2 上 `web_fetch https://example.com` 返回 HTTP 200 + 解码正文；0.1.1 上同配置启动正常（无提供方时仅调用报错）。
+- **`kix-webhook`：外部事件 → kix 会话（默认关）**：新增规则层插件（事件匹配 / 机器人忽略 / `maxSessions` fuse / prompt 模板插值），把一条已验证投递翻成宿主 `ctx.webhookRuntime` 的会话请求。默认档与 null 档均 `enabled: false`（发布默认关）；HTTP 入口与签名密钥属部署面，参考行在 `dsh/preset/patches/kix-webhook.reference.yml` + 覆盖层 `kix-webhook.runtime-overlay.yml`。激励面两副本字节一致，身份组登记只比两副本（classic/en 不部署——其组成不挂 webhookRuntime，多副本只会成悬空行）。实测（隔离 DSH_HOME + 真实 home 各一轮）：签名 POST → 202 → 新建 `webhook-*` 会话（preset=kixparadigm、system prompt 含 kixParadigm、prompt 由模板生成）→ 会话真实执行。
+- **两条新机制事实（写进插件头与参考文件）**：①**profile 的 patch 覆盖不到 preset 组成内部的行**（配置面探针：预设 `disabled:true` + patch 只覆盖 `config` → 插件仍不加载），启用必须改预设文件；②**预设是 lazy mount**——冷启动后、任何会话之前的投递只回 202、不起会话；③**202 ≠ 处理成功**：入口校验失败才回 4xx/5xx，规则/建会话失败只写宿主日志。
+- **原生子代理模型选型：验证可用、不默认开**：`dsh-tool-subagent.modelSelectionSettings`（0.1.1 无此字段）实测在 kix 组成下可用——schema 多出 `provider`/`model`/`reasoning_effort`、`subagent/model-selection-policy` 事件写入会话、`list_subagent_models` 返回白名单路由。未默认开的两条机械理由：宿主缺 `model-selection-settings` 行时**挂载即抛错**（非降级，会拖垮整个 preset）；白名单只认已注册 provider，写死等于把预设绑到某台机器的模型目录。步骤与实测边界见 `dsh/README-DSH.md`。
+- **门禁**：`npm test` 50 pass / 0 fail / 1 skip（含 kix-webhook 单测 13 条）· `check-dsh-consistency` CONSISTENCY OK（`kix-webhook.js/.test.js: 2 copies byte-identical`）· `kix4.test.js` composition parity PASS（default/null 均 33 行）· `audit-selection-pressure-history --check` exit 0 · 0.1.2-rc.1 上端到端复验（web_fetch + webhook→会话）· 独立观察者只读复核（4 findings 全部修复：null parity、启用指引、202 语义、缺服务测试覆盖）。
+
 ## v1.3.13（2026-09-08）自举审计闭环：单源、悬空引用、守护布局无关
 
 - **能力地图单源**：`skills/kixpower/dsh-capability-map.md` 经 diff 确认是 `memories/dsh-capability-map.md` 的旧子集（140 vs 202 行，无独有内容），删除重复副本。全部锚点由 `§数字` 改标题——classic 是 §6、默认档是 §4，只有标题「动态 Cordis 插件实测机制事实」两档都能命中；引用方 `kix-stalled.js`/`kixpower-v39-legacy-notes.md`/`kixpower-workflow.template.md` 同步改标题锚点。

--- a/dsh/README-DSH.md
+++ b/dsh/README-DSH.md
@@ -68,7 +68,8 @@ pwsh -File .\scripts\sync-dsh-preset.ps1 -Force
 - `skills/` — 目录指针 → `../preset-classic/skills`（kixparadigm / kixpower 等按需技能）
 - `prompts/` — /kixpower-* 流程（kix-commands 插件注入用）
 - `memories/` — 方法论记忆（目录清单为准；含 incentive-lessons）
-- `plugins/` — kix-guards / kix-cost / kix-route / kix-commands / kix-stalled（默认启用、candidate keep）+ 测试
+- `plugins/` — kix-guards / kix-cost / kix-route / kix-commands / kix-stalled（默认启用、candidate keep）+ kix-webhook（默认 disabled，外部事件桥）+ 测试
+- `patches/kix-webhook.reference.yml` — webhook 部署参考行（profile 侧 insert + 凭据 + 自测命令）
 
 默认档根**不部署** `DSH-ADAPTATION.md`、`DSH-FUSION-MATRIX.md`、`instructions/`；`skills/` 与 `agents/` 在仓库里是指向 classic 的指针，安装时物化为真目录（保证货架内 `../../agents/*.agent.md` 等相对链接可达）。权威机制映射在 [`preset-classic/DSH-ADAPTATION.md`](preset-classic/DSH-ADAPTATION.md) 与 [`preset-classic/DSH-FUSION-MATRIX.md`](preset-classic/DSH-FUSION-MATRIX.md)。
 
@@ -83,6 +84,46 @@ node --test dsh\vision-bridge\test.js           # vision-bridge 纯逻辑回归
 ```
 
 preset 挂载校验（roster `standingKeyFor`）在 DSH 会话内用 cordis 工具集执行。
+
+## DSH 0.1.2 原生能力对接（2026-09-09 实测）
+
+本机安装 `0.1.1-rc.2`；npm latest = `0.1.2-rc.1`、alpha = `0.1.5-alpha.1`。隔离 DSH_HOME + 0.1.2-rc.1 实测：kix 预设零改动即可加载并跑通（system prompt 含 kixParadigm/三通道/需求三检，9 个 kix 机制工具全部注册）。三处对接：
+
+| 能力 | 状态 | 落点 |
+|---|---|---|
+| `web_fetch`（宿主提供方 `dsh-web-fetch-http`） | 已落地 | 本预设 `tool-web.config.fetch: true`；0.1.1 无提供方时调用报错、不影响启动 |
+| 子代理原生模型选型（`modelSelectionSettings`） | 已验证，未默认开 | 见下：需宿主设置命名空间 + 白名单，属部署决策 |
+| webhook → kix 会话 | 已落地（默认 disabled） | `plugins/kix-webhook.js` + `patches/kix-webhook.reference.yml` |
+
+### 子代理原生模型选型（为什么没有默认打开）
+
+DSH 0.1.2 给 `dsh-tool-subagent` 加了 `modelSelectionSettings`（0.1.1 无此字段）：置 true 后，工具 schema 多出 `provider`/`model`/`reasoning_effort` 三个参数，子调用可显式选型；白名单来自宿主设置命名空间 `subagent-model-selection`（`enabled` + `allowedModels[]` 精确 provider/model 对），并把策略作为 `subagent/model-selection-policy` 投影事件记进会话。
+
+**未默认开的两条机械理由**：①该行要求宿主已挂 `@deepseek-ai/dsh-tool-subagent/model-selection-settings`，缺失时**挂载即抛错**（不是降级），会让整个 preset 装不上；②白名单只认已注册 provider，本机 `zai-coding-cn` / `grok` 由部署 `settings.yaml` 提供，写死在预设里等于把预设绑到某台机器的模型目录。
+
+**打开步骤**（部署侧，两处）：profile patch 里加 `@deepseek-ai/dsh-tool-subagent/model-selection-settings` 行；`$DSH_HOME/settings.yaml` 写：
+
+```yaml
+subagent-model-selection:
+  enabled: true
+  allowedModels:
+    - provider: zai-coding-cn
+      model: glm-5.3
+    - provider: grok
+      model: grok-4.5
+```
+
+然后把 `agent.cordis.yml` 的 `tool-subagent` 行加 `modelSelectionSettings: true`。**实测边界**（2026-09-09，隔离环境）：kix 预设 + 上述配置 → schema 出现三个参数、策略事件写入、`list_subagent_models` 返回白名单路由；`subagent` 工具本身被 kix-focus 的 `tools.restrict()` 裁剪（`unknown global tool "subagent"`），所以端到端调用要在未被 restrict 的档位（如 `subagent_lite`，或临时关掉 focus 裁剪）上验。**它替代不了 kix 分档**：`subagent_lite` 的独立 persona + toolFilter 裁剪（省固定开销）与模型选型是两件事。
+
+### webhook → kix 会话（规则层常驻加载、config 默认关）
+
+`ctx.webhookRuntime`（0.1.2 新增，唯一内置动作 = 在 Web Workspace 建 root Session）+ `@deepseek-ai/dsh-webhook-github`（HMAC 校验、202 不等规则）都不在默认组合里，属部署面。本仓提供规则层 `plugins/kix-webhook.js`（事件匹配 / 机器人忽略 / `maxSessions` fuse / prompt 插值）与参考行 `patches/kix-webhook.reference.yml`。预设里该行**不设 disabled**、以 `config.enabled: false` 常驻加载（未启用时 apply 直接返回，无注入无监听）。
+
+两条实测结论（2026-09-09，隔离环境）：
+- **profile 的 patch 覆盖不到 preset 组成里的行**。探针：`- id: kix-webhook` + config 写进 profile patch（预设侧 `enabled:false`）→ 插件仍以 `enabled:false` 加载；把同样内容写进预设文件 → 立即生效（规则注册、签名 POST 202 → 新建 `webhook-*` 会话，preset=kixparadigm，system prompt 含 kixParadigm/三通道）。所以开关要改预设文件，不能只改 profile patch——参考文件 §2 已按此写。
+- **预设是 lazy mount**：首次有会话挂载它时插件才加载。冷启动后、任何会话之前到来的投递只回 202、不起会话（要「开机即接事件」就先挂一个会话）。
+
+0.1.1 及更早无 `webhookRuntime`：`inject` 保持 pending，同样零副作用。外部可达性（公网入口）未验证，参考文件里写清了。
 
 ### 常驻承诺与死亡条款的结算工具（只读，非门禁）
 

--- a/dsh/preset-classic/plugins/consistency-lib.cjs
+++ b/dsh/preset-classic/plugins/consistency-lib.cjs
@@ -315,6 +315,10 @@ const PLUGIN_IDENTITY_GROUPS = {
   'kix-probe.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-settle.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-mem.js': [['kixparadigm', 'kixparadigm-null']],
+  // 2026-09-09：webhook 桥是部署面规则层（GitHub 适配器 → webhookRuntime → kix 会话），
+  // 不属范式认知面 → 只比激励面两副本。classic/en 档不部署（其 composition 不挂
+  // webhookRuntime，多一份副本只会变成悬空行）。
+  'kix-webhook.js': [['kixparadigm', 'kixparadigm-null']],
 }
 
 function pluginSourceName(name) {

--- a/dsh/preset-null/agent.cordis.yml
+++ b/dsh/preset-null/agent.cordis.yml
@@ -848,3 +848,16 @@
 # 插件面；死亡条款与完整背景见默认版注释：一个月真实使用 <2 次回退渐进披露）
 - id: kix-browser
   name: ./plugins/kix-browser.js
+
+# kix-webhook（外部事件 → kix 会话，2026-09-09；与默认版同步——null 变体同
+# 插件面，parity 契约见 plugins/kix4.test.js）。常驻加载但 config.enabled: false
+# → apply 直接返回，无注入/监听/模型可见面，对消融面无行为影响。
+# 完整背景与启用步骤见默认版注释与 dsh/preset/patches/kix-webhook.reference.yml。
+- id: kix-webhook
+  name: ./plugins/kix-webhook.js
+  config:
+    enabled: false
+    workspacePath: /absolute/path/to/workspace
+    agentPreset: kixparadigm
+    permissionPreset: danger-full-access
+    maxSessions: 1

--- a/dsh/preset-null/plugins/consistency-lib.cjs
+++ b/dsh/preset-null/plugins/consistency-lib.cjs
@@ -315,6 +315,10 @@ const PLUGIN_IDENTITY_GROUPS = {
   'kix-probe.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-settle.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-mem.js': [['kixparadigm', 'kixparadigm-null']],
+  // 2026-09-09：webhook 桥是部署面规则层（GitHub 适配器 → webhookRuntime → kix 会话），
+  // 不属范式认知面 → 只比激励面两副本。classic/en 档不部署（其 composition 不挂
+  // webhookRuntime，多一份副本只会变成悬空行）。
+  'kix-webhook.js': [['kixparadigm', 'kixparadigm-null']],
 }
 
 function pluginSourceName(name) {

--- a/dsh/preset-null/plugins/kix-webhook.js
+++ b/dsh/preset-null/plugins/kix-webhook.js
@@ -1,0 +1,186 @@
+// kix-webhook — 把外部事件（GitHub webhook）变成一个 kix 会话（DSH 0.1.2+ 原生能力）
+//
+// 定位：DSH 0.1.2 起提供宿主 `ctx.webhookRuntime`（`register(rule)` / `dispatch(delivery)`，
+// 唯一内置动作 = 在 Web Workspace 里创建普通 root Session）与 `@deepseek-ai/dsh-webhook-github`
+// 适配器（校验 GitHub 原始 body 的 HMAC 签名，投递后返回 202 不等规则结算）。本插件是
+// **规则层**：把一条已验证投递翻译成 `WebhookSessionRequest`，让 PR/issue 事件直接起一个
+// 按 kix 范式组合的会话，而不是等主线程轮询。
+//
+// 分层（不要在本插件里做的事）：
+//   - HTTP 入口/签名校验 = `dsh-webhook-github`（profile 侧 insert 行）
+//   - 会话创建与编排 = `ctx.webhookRuntime`（宿主面）
+//   - 规则（事件 → 会话请求、去重、并发闸）= 本插件
+// 这三层都缺席时本插件静默不注册（inject 保持 pending），不报错、不产生副作用。
+//
+// 2026-09-09 实测（WSL2，DSH 0.1.2-rc.1，隔离 DSH_HOME）：
+//   - 签名 POST /api/probe-webhook/github → 202 → 规则命中 → 新建 root Session
+//     （agentPreset=kixparadigm，system prompt 含 kixParadigm/三通道/需求三检）
+//   - 该会话真实执行：user/message(source.kind=webhook) → assistant/message "WEBHOOK-OK"
+//   结论：链路成立；**外部可达性另算**——`dsh web` 默认只绑 127.0.0.1，GitHub 真投递
+//   需要隧道或反代，属部署面，不在本插件职责内。
+//
+// 配置（**预设行**的 config，见 dsh/preset/patches/kix-webhook.reference.yml）：
+//   enabled            总开关，默认 false（部署侧显式打开）
+//   workspacePath      会话工作区绝对路径（必填；必须是已存在目录）
+//   agentPreset        会话组合，默认 kixparadigm
+//   permissionPreset   sandbox/approval 预置，默认 danger-full-access
+//   events             触发的事件名（默认 pull_request.opened / issues.opened）
+//   ignoreSenders      忽略的 sender.login（默认 github-actions[bot] / *[bot] 通配）
+//   maxSessions        本进程内最多由 webhook 起的会话数，默认 1（失控 fuse）
+//   promptTemplate     会话初始 prompt 模板，{{key}} 从投递上下文插值
+//
+// 启用必须改**预设文件**里的这一行（$DSH_HOME/.agent-presets/<preset>/agent.cordis.yml），
+// 不是 profile 的 cordis.patch.yml：2026-09-09 配置面探针实测 profile patch 覆盖不到
+// preset 组成内部的行（只覆盖 HTTP 入口那两行 insert）。详见 reference §2。
+// 另：预设是 lazy mount，首次有会话挂载它时本插件才加载——冷启动后、任何会话之前的
+// 投递只回 202、不起会话。
+//
+// 规则是负债：不做队列、不做重试、不做持久化去重（GitHub 自身按 delivery id 重投，
+// 重复投递最多多起一个会话，由 maxSessions 兜底）。需要更强保证时在部署侧加。
+
+'use strict'
+
+const DEFAULT_AGENT_PRESET = 'kixparadigm'
+const DEFAULT_PERMISSION_PRESET = 'danger-full-access'
+const DEFAULT_EVENTS = ['pull_request.opened', 'issues.opened']
+const DEFAULT_IGNORE_SENDERS = ['*[bot]']
+const DEFAULT_MAX_SESSIONS = 1
+const DEFAULT_PROMPT =
+  '外部事件触发：{{event}}（{{repository}}）。请按 kix 范式处理这个事件，先给出你的处理计划。'
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isAbsolute(value) {
+  if (!isNonEmptyString(value)) return false
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
+}
+
+// 通配匹配：只支持 '*' 前缀/后缀/全匹配（够用，不做正则——避免配置里注入模式）
+function matchesPattern(value, pattern) {
+  if (typeof value !== 'string' || typeof pattern !== 'string') return false
+  if (pattern === '*') return true
+  if (pattern.startsWith('*')) return value.endsWith(pattern.slice(1))
+  if (pattern.endsWith('*')) return value.startsWith(pattern.slice(0, -1))
+  return value === pattern
+}
+
+// 把 GitHub 投递压成插值上下文；payload 形状按事件不同，缺失字段一律空串
+function contextOf(delivery) {
+  const event = delivery && delivery.event ? delivery.event : {}
+  const payload = event && event.payload && typeof event.payload === 'object' ? event.payload : {}
+  const pr = payload.pull_request || {}
+  const issue = payload.issue || {}
+  const repo = payload.repository || {}
+  const sender = payload.sender || {}
+  return {
+    event: isNonEmptyString(event.name) ? event.name : '',
+    action: isNonEmptyString(payload.action) ? payload.action : '',
+    repository: isNonEmptyString(repo.full_name) ? repo.full_name : '',
+    sender: isNonEmptyString(sender.login) ? sender.login : '',
+    number: String(pr.number ?? issue.number ?? payload.number ?? ''),
+    title: isNonEmptyString(pr.title) ? pr.title : (isNonEmptyString(issue.title) ? issue.title : ''),
+    url: isNonEmptyString(pr.html_url) ? pr.html_url : (isNonEmptyString(issue.html_url) ? issue.html_url : ''),
+    delivery: isNonEmptyString(delivery && delivery.deliveryId) ? delivery.deliveryId : '',
+  }
+}
+
+// 模板插值：未命中的 key 保留原样（暴露配置错误，不静默吞掉）
+function renderTemplate(template, context) {
+  return String(template).replace(/\{\{([a-zA-Z0-9_]+)\}\}/g, (whole, key) =>
+    Object.prototype.hasOwnProperty.call(context, key) ? context[key] : whole)
+}
+
+function eventKey(delivery) {
+  const event = delivery && delivery.event ? delivery.event : {}
+  const payload = event && event.payload && typeof event.payload === 'object' ? event.payload : {}
+  const name = isNonEmptyString(event.name) ? event.name : ''
+  const action = isNonEmptyString(payload.action) ? payload.action : ''
+  return action ? `${name}.${action}` : name
+}
+
+function normalizeConfig(config) {
+  const raw = config && typeof config === 'object' ? config : {}
+  const events = Array.isArray(raw.events) && raw.events.length > 0
+    ? raw.events.filter(isNonEmptyString)
+    : DEFAULT_EVENTS.slice()
+  const ignoreSenders = Array.isArray(raw.ignoreSenders)
+    ? raw.ignoreSenders.filter(isNonEmptyString)
+    : DEFAULT_IGNORE_SENDERS.slice()
+  const maxSessions = Number.isSafeInteger(raw.maxSessions) && raw.maxSessions >= 0
+    ? raw.maxSessions
+    : DEFAULT_MAX_SESSIONS
+  return {
+    enabled: raw.enabled === true,
+    workspacePath: isNonEmptyString(raw.workspacePath) ? raw.workspacePath : undefined,
+    agentPreset: isNonEmptyString(raw.agentPreset) ? raw.agentPreset : DEFAULT_AGENT_PRESET,
+    permissionPreset: isNonEmptyString(raw.permissionPreset) ? raw.permissionPreset : DEFAULT_PERMISSION_PRESET,
+    events,
+    ignoreSenders,
+    maxSessions,
+    promptTemplate: isNonEmptyString(raw.promptTemplate) ? raw.promptTemplate : DEFAULT_PROMPT,
+  }
+}
+
+// 纯函数：投递 → 会话请求（null = 不动作）。测试直接打这个面。
+function decide(delivery, cfg, state) {
+  const config = normalizeConfig(cfg)
+  const counters = state && typeof state === 'object' ? state : { started: 0 }
+  if (!config.enabled) return null
+  if (!isAbsolute(config.workspacePath)) return null
+  if (typeof counters.started === 'number' && counters.started >= config.maxSessions) return null
+  if (!delivery || typeof delivery !== 'object') return null
+  const key = eventKey(delivery)
+  if (!config.events.some((pattern) => matchesPattern(key, pattern))) return null
+  const context = contextOf(delivery)
+  if (context.sender && config.ignoreSenders.some((pattern) => matchesPattern(context.sender, pattern))) return null
+  const prompt = renderTemplate(config.promptTemplate, context)
+  if (!isNonEmptyString(prompt)) return null
+  const title = context.number
+    ? `${context.event}#${context.number} ${context.title || context.action || ''}`.trim()
+    : `${context.event} ${context.action}`.trim()
+  return {
+    workspacePath: config.workspacePath,
+    title: title || 'webhook',
+    prompt,
+    agentPreset: config.agentPreset,
+    permissionPreset: config.permissionPreset,
+  }
+}
+
+const name = 'kix-webhook'
+
+function apply(ctx, config) {
+  const normalized = normalizeConfig(config)
+  if (!normalized.enabled) {
+    ctx.logger.info('kix-webhook: disabled (set enabled: true in the PRESET row config — $DSH_HOME/.agent-presets/<preset>/agent.cordis.yml — not the profile patch; see dsh/preset/patches/kix-webhook.reference.yml §2)')
+    return
+  }
+  if (!isAbsolute(normalized.workspacePath)) {
+    ctx.logger.warn('kix-webhook: workspacePath must be an absolute existing directory; rule not registered')
+    return
+  }
+  const state = { started: 0 }
+  ctx.inject(['webhookRuntime'], (scope) => {
+    scope.effect(() => {
+      const dispose = scope.webhookRuntime.register({
+        id: 'kix-webhook',
+        kind: 'github',
+        run(delivery) {
+          const request = decide(delivery, normalized, state)
+          if (request === null) {
+            ctx.logger.debug(`kix-webhook: delivery ${delivery && delivery.deliveryId} ignored`)
+            return null
+          }
+          state.started += 1
+          ctx.logger.info(`kix-webhook: starting session "${request.title}" (${state.started}/${normalized.maxSessions})`)
+          return request
+        },
+      })
+      return () => { void dispose() }
+    })
+  })
+}
+
+module.exports = { name, apply, decide, renderTemplate, matchesPattern, normalizeConfig, contextOf, eventKey }

--- a/dsh/preset-null/plugins/kix-webhook.test.js
+++ b/dsh/preset-null/plugins/kix-webhook.test.js
@@ -1,0 +1,153 @@
+'use strict'
+
+// kix-webhook 单元测试（2026-09-09）
+//
+// 测的是 decide() 的行为面：投递 → 会话请求（或 null）。不 mock webhookRuntime 的
+// 内部实现，只验证本插件自己的规则层（事件匹配/忽略名单/并发闸/插值/绝对路径闸）。
+// 真实链路（签名 HTTP → dispatch → 起会话 → 模型执行）由部署侧 E2E 覆盖，
+// 见插件头部注释的 2026-09-09 实测记录。
+
+const assert = require('node:assert/strict')
+const { test } = require('node:test')
+const plugin = require('./kix-webhook.js')
+
+function delivery(overrides = {}) {
+  const { name = 'pull_request', action = 'opened', payload = {}, ...rest } = overrides
+  return {
+    kind: 'github',
+    source: 'primary-github',
+    deliveryId: 'delivery-1',
+    receivedAt: 1_788_900_000_000,
+    event: {
+      name,
+      payload: {
+        action,
+        pull_request: { number: 42, title: 'add webhook bridge', html_url: 'https://github.com/o/r/pull/42' },
+        repository: { full_name: 'o/r' },
+        sender: { login: 'alice' },
+        ...payload,
+      },
+    },
+    ...rest,
+  }
+}
+
+const baseConfig = { enabled: true, workspacePath: '/tmp/ws', maxSessions: 1 }
+
+test('disabled config never starts a session', () => {
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, enabled: false }, { started: 0 }), null)
+})
+
+test('workspacePath must be absolute', () => {
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, workspacePath: 'relative/path' }, { started: 0 }), null)
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, workspacePath: undefined }, { started: 0 }), null)
+  assert.ok(plugin.decide(delivery(), { ...baseConfig, workspacePath: 'C:\\ws' }, { started: 0 }))
+})
+
+test('default events are pull_request.opened and issues.opened', () => {
+  assert.ok(plugin.decide(delivery(), baseConfig, { started: 0 }))
+  assert.ok(plugin.decide(delivery({ name: 'issues' }), baseConfig, { started: 0 }))
+  assert.equal(plugin.decide(delivery({ action: 'closed' }), baseConfig, { started: 0 }), null)
+  assert.equal(plugin.decide(delivery({ name: 'push', action: undefined }), baseConfig, { started: 0 }), null)
+})
+
+test('event patterns support prefix/suffix wildcards', () => {
+  const cfg = { ...baseConfig, events: ['pull_request.*'] }
+  assert.ok(plugin.decide(delivery({ action: 'synchronize' }), cfg, { started: 0 }))
+  assert.equal(plugin.decide(delivery({ name: 'issues' }), cfg, { started: 0 }), null)
+})
+
+test('bot senders are ignored by default', () => {
+  const bot = delivery({ payload: { sender: { login: 'dependabot[bot]' } } })
+  assert.equal(plugin.decide(bot, baseConfig, { started: 0 }), null)
+  assert.ok(plugin.decide(delivery({ payload: { sender: { login: 'alice' } } }), baseConfig, { started: 0 }))
+})
+
+test('maxSessions acts as a fuse', () => {
+  assert.equal(plugin.decide(delivery(), baseConfig, { started: 1 }), null)
+  assert.ok(plugin.decide(delivery(), { ...baseConfig, maxSessions: 2 }, { started: 1 }))
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, maxSessions: 0 }, { started: 0 }), null)
+})
+
+test('request carries the configured preset surface and a rendered title', () => {
+  const request = plugin.decide(delivery(), baseConfig, { started: 0 })
+  assert.equal(request.workspacePath, '/tmp/ws')
+  assert.equal(request.agentPreset, 'kixparadigm')
+  assert.equal(request.permissionPreset, 'danger-full-access')
+  assert.equal(request.title, 'pull_request#42 add webhook bridge')
+  assert.match(request.prompt, /pull_request/)
+  assert.match(request.prompt, /o\/r/)
+})
+
+test('promptTemplate interpolates delivery context and keeps unknown keys literal', () => {
+  const rendered = plugin.renderTemplate('{{event}} {{action}} {{number}} {{missing}}', {
+    event: 'issues', action: 'opened', number: '7',
+  })
+  assert.equal(rendered, 'issues opened 7 {{missing}}')
+})
+
+test('malformed deliveries are ignored instead of throwing', () => {
+  assert.equal(plugin.decide(null, baseConfig, { started: 0 }), null)
+  assert.equal(plugin.decide({}, baseConfig, { started: 0 }), null)
+  assert.equal(plugin.decide({ event: {} }, baseConfig, { started: 0 }), null)
+})
+
+test('apply while disabled returns before injecting (no service lookup, one log)', () => {
+  const logs = []
+  const ctx = {
+    logger: { info: (m) => logs.push(['info', m]), warn: (m) => logs.push(['warn', m]), debug: () => {} },
+    inject: () => { throw new Error('should not inject while disabled') },
+  }
+  plugin.apply(ctx, { enabled: false })
+  assert.equal(logs.length, 1)
+  assert.match(logs[0][1], /disabled/)
+  // 提示必须指向**预设行**（profile patch 覆盖不到 preset 内部行，实测 2026-09-09）
+  assert.match(logs[0][1], /PRESET row/)
+})
+
+// enabled=true 但宿主没有 webhookRuntime（0.1.1 及更早）时：插件不得抛错，
+// 只调用一次 inject 并就此停住（cordis 语义：依赖未满足的 fiber 保持 pending，
+// 服务出现后再执行回调）。本用例只证明「不抛错 + 恰好一次 inject + 无注册」；
+// 真正的 pending→恢复语义属宿主 cordis，不在本单测覆盖范围内。
+test('apply with enabled=true but no webhookRuntime stays pending without throwing', () => {
+  const logs = []
+  const injects = []
+  const ctx = {
+    logger: { info: (m) => logs.push(['info', m]), warn: (m) => logs.push(['warn', m]), debug: () => {} },
+    inject: (services, cb) => { injects.push(services); return { dispose() {} } },
+  }
+  assert.doesNotThrow(() => plugin.apply(ctx, { enabled: true, workspacePath: '/tmp/ws' }))
+  assert.equal(injects.length, 1)
+  assert.deepEqual(injects[0], ['webhookRuntime'])
+  assert.equal(logs.length, 0)
+})
+
+test('apply refuses a non-absolute workspacePath before injecting', () => {
+  const logs = []
+  let injected = false
+  const ctx = {
+    logger: { info: () => {}, warn: (m) => logs.push(m), debug: () => {} },
+    inject: () => { injected = true },
+  }
+  plugin.apply(ctx, { enabled: true, workspacePath: 'relative' })
+  assert.equal(injected, false)
+  assert.match(logs[0], /absolute/)
+})
+
+test('apply registers a github rule that honours the session fuse', () => {
+  const registered = []
+  const scope = {
+    effect: (fn) => { fn(); return () => {} },
+    webhookRuntime: { register: (rule) => { registered.push(rule); return () => {} } },
+  }
+  const ctx = {
+    logger: { info: () => {}, warn: () => {}, debug: () => {} },
+    inject: (services, cb) => { assert.deepEqual(services, ['webhookRuntime']); cb(scope) },
+  }
+  plugin.apply(ctx, { enabled: true, workspacePath: '/tmp/ws', maxSessions: 1 })
+  assert.equal(registered.length, 1)
+  assert.equal(registered[0].id, 'kix-webhook')
+  assert.equal(registered[0].kind, 'github')
+  assert.ok(registered[0].run(delivery(), new AbortController().signal))
+  assert.equal(registered[0].run(delivery(), new AbortController().signal), null)
+})

--- a/dsh/preset/agent.cordis.yml
+++ b/dsh/preset/agent.cordis.yml
@@ -131,10 +131,10 @@
 
       ## 思考锚点
       - 三通道：执行产出 claim；重要 claim 自主展开异质观察集群，可递归分派 probe；有效反例优先裁决，APPROVE 不投票也不触发补票。视角与模型两轴不可互替——独立上下文≠跨厂商/权重独立，同权重观察者会共享盲点。外部语义密集 claim 至少 1 条跨厂商或可重放物证通道；按信息缺口自由发散，本机制不新增人数/深度/fan-out/token 限制。验证前对照盲点：深度不足/读写混淆/语言语义/自信偏差/辩护倾向/外部视野/过度工程/架构方向；有疑虑调独立 agent。
-      - 阶段二相性：创造最小规则，验证结构化补盲；两阶段不互泄漏——自我验证被创造视角污染，故需独立 agent。会改变实现的 design observer 结算前不编辑目标；final review 绑定冻结 artifact，编辑即失效重开。只有新反例/新风险/artifact 变化重开，失败调用按零证据且不机械补派。
+      - 阶段二相性：创造最小规则，验证结构化补盲；独立观察保留用户目标/适用契约，不灌主张者的论证。会改变实现的 design observer 结算前不编辑目标；final review 绑定 artifact 与依据，任一变化先重估影响范围，只重验失效证据。旧观察/旧测试不自动为新版本背书；失败调用按零证据且不机械补派。
       - 规则是负债：常驻行为承诺须有承载层——可机械观测→plugin/audit；语义权衡→激励/选择压；低频危机→memory；两轮无实证收益→删。新增机制先问「LLM 瓶颈还是人类组织投影」。
-      - 需求三检（信号命中才做）：目标不明 / 影响大不可逆 / 含实现方案词汇。①XY ②前提 ③路径。字面明确低风险可逆直接做。行为契约（必须不变/改变/成立/歧义解读）写入 kix_discipline_spec 的 contract；有歧义先问。
-      - 写码前：需要存在吗→仓库已有→标准库→平台原生→已装依赖→一行→最小可行。修根因。改事件/类型/平台/外部 API 时交付前三问：测试镜像真实链路吗（stub 藏 bug）；证据维度对吗（调用链≠语义）；关键 claim 独立验证过吗。提交前跑标准 lint/test。
+      - 需求三检（信号命中才做）：目标不明 / 影响大不可逆 / 含实现方案词汇。①XY ②前提 ③路径。字面明确低风险可逆直接做。继续/修补/复核/交接继承当前用户目标与适用约束，用户改约即更新；旧方案和 finding 清单不替代验收。需留痕时复用 kix_discipline_spec.contract 或既有任务文档，注明来源与任务归属，勿误用被其他任务覆盖的 spec。仅影响决策且无法从上下文消解的歧义才问。
+      - 写码前：需要存在吗→仓库已有→标准库→平台原生→已装依赖→一行→最小可行。每次方案实质变化都对照原目标重判必要性与净收益；必要跨包改动/依赖可以采用，不按行数或原则名判错。修根因。交付前三问：测试镜像真实链路吗（stub 藏 bug）；证据维度对吗（调用链≠语义）；关键 claim 独立验证过吗。旧缺陷修复、测试绿、工具成功或代理完成只支持各自覆盖范围；总体完成须有当前目标/约束的依据，关键未知不能藏在通过结论之后。提交前跑标准 lint/test。
 
       ## 选择压（看菜单，不走仪式）
       - 属性路由：规模≥3文件 / 外部副作用 / 验证关键 / 目标不明 → 先 kix_capability_search 再动手。禁止类型→动作静态映射。
@@ -761,10 +761,18 @@
 # （cacheRead:input 实测 127:1，长会话全价重读）远超省下的 660 tok/步常驻税；
 # 且 scope-local 工具 restrict 裁不到，渐进披露需要 cordis disabled + 激活
 # 双重机制。web_search 小（660 tok）低频 → 常驻税可接受，零断缓存风险。
+#
+# 2026-09-09 `fetch: true`（DSH 0.1.2 起）：web_fetch 给 kix 的「外部语义密集
+# claim 至少一条可重放物证通道」补上原文取证面（状态码 + 解码正文，带 URL
+# 校验/公网解析/同源重定向/字节上限）。0.1.1 曾以 `fetch: false` 关闭，理由是
+# 当时**没有宿主侧 fetch 提供方**——注释原文：provider 缺失时 SSRF 防护后移、
+# 请求目标由模型选。0.1.2 的 `dsh-web-fetch-http` 提供方（base 层默认挂载）
+# 承担了这层防护，故打开是净收益；宿主未挂提供方时调用报错、不影响启动
+# （0.1.1 实测：启动正常）。
 - id: tool-web
   name: '@deepseek-ai/dsh-tool-web'
   config:
-    fetch: false
+    fetch: true
     searchTimeoutMs: 60000
 
 # ── kix 机械门禁（DSH 原生 hook）────────────────────────────────────────────
@@ -976,3 +984,34 @@
 # KIX_BROWSER_CORE 显式指路；懒加载，未安装不影响其他工具。
 - id: kix-browser
   name: ./plugins/kix-browser.js
+
+# ── kix-webhook（外部事件 → kix 会话，2026-09-09 实测落地）────────────────
+# DSH 0.1.2 起提供宿主 `ctx.webhookRuntime`（唯一内置动作 = 在 Web Workspace
+# 建一个普通 root Session）+ `@deepseek-ai/dsh-webhook-github`（校验 GitHub
+# 原始 body 的 HMAC 签名，202 投递不等规则）。本行是**规则层**：把一条已验证
+# 投递翻成会话请求（事件匹配/机器人忽略/并发 fuse/prompt 插值）。
+#
+# 默认 disabled：HTTP 入口与签名密钥属部署面（profile 的 cordis.patch.yml +
+# 凭据库），预设不替部署做这个决定。启用步骤与参考行见
+# dsh/preset/patches/kix-webhook.reference.yml；0.1.1-rc.2 及更早无
+# webhookRuntime，本行即使打开也只静默不注册（inject 保持 pending）。
+#
+# 2026-09-09 隔离环境实测（DSH 0.1.2-rc.1，WSL2）：签名 POST → 202 → 规则命中
+# → 新建 root Session（agentPreset=kixparadigm，system prompt 含 kixParadigm/
+# 三通道/需求三检）→ 会话真实执行并回复。外部可达性（公网入口）不在插件职责内。
+#
+# 行**不**设 disabled：DSH 实测「行状 patch 只覆盖声明的键，不会把 disabled 翻回」
+# （配置面探针：预设 disabled:true + patch 只覆盖 config → 插件仍不加载）。
+# 因此本行常驻加载，开关完全走 config.enabled；未启用时 apply 直接返回，
+# 无注入、无监听、无成本；宿主无 webhookRuntime（0.1.1 及更早）时 inject 保持
+# pending，同样零副作用。
+- id: kix-webhook
+  name: ./plugins/kix-webhook.js
+  config:
+    # 启用 = 改**本行**（安装副本 $DSH_HOME/.agent-presets/kixparadigm/agent.cordis.yml），
+    # profile 的 cordis.patch.yml 覆盖不到 preset 内部行；见 patches/kix-webhook.reference.yml §2
+    enabled: false
+    workspacePath: /absolute/path/to/workspace
+    agentPreset: kixparadigm
+    permissionPreset: danger-full-access
+    maxSessions: 1

--- a/dsh/preset/patches/kix-webhook.reference.yml
+++ b/dsh/preset/patches/kix-webhook.reference.yml
@@ -1,0 +1,103 @@
+# kix-webhook 参考部署（外部事件 → kix 会话）
+#
+# 两处改动：①profile 的 cordis.patch.yml 加 HTTP 入口两行 insert（或改用同目录的
+# `kix-webhook.runtime-overlay.yml` 作 `--patch` 覆盖层，不动 profile）；②预设文件的
+# kix-webhook 行把 config.enabled 改成 true（profile patch 覆盖不到 preset 组成里的行，
+# 见 §2 的实测结论）。kix 预设只提供规则层；HTTP 入口与签名密钥属于部署，预设不替部署决定。
+#
+# 目标 profile（本机）：$DSH_HOME/profiles/web/cordis.patch.yml
+# 前置：DSH ≥ 0.1.2-rc.1（0.1.1 无 ctx.webhookRuntime 与 dsh-webhook-github）
+#
+# 覆盖层用法（2026-09-09 实测：flag 必须放 launcher 位置，`dsh web --patch` 会报
+# "web takes none of parent --patch"）：
+#   dsh --profile web --patch <repo>/dsh/preset/patches/kix-webhook.runtime-overlay.yml --port <p> --no-open
+# 实测该组合：boot 正常、路由挂载（GET → 405 method not allowed）、签名 POST → 202。
+#
+# ── 1. 挂载（把下面整段追加到 profile 的 cordis.patch.yml 末尾）─────────────
+#
+# - insert:
+#     # 宿主运行时：规则注册 + 唯一内置动作（在 Web Workspace 建 root Session）
+#     - id: webhook-runtime
+#       name: '@deepseek-ai/dsh-webhook'
+#
+#     # GitHub 适配器：校验 x-hub-signature-256，投递后立刻回 202
+#     - id: webhook-github
+#       name: '@deepseek-ai/dsh-webhook-github'
+#       config:
+#         source: primary-github
+#         path: /api/kix-webhook/github
+#         secretEnv: KIX_WEBHOOK_SECRET     # 凭据库引用名，不是明文
+#         maxBodyBytes: 262144
+#
+# ── 2. 打开 kix 规则层（改**预设文件**，不是 profile patch）────────────────
+#
+# 实测（2026-09-09，配置面探针）：profile 的 patch 行**覆盖不到 preset 组成里的行**。
+# 探针把 `- id: kix-webhook` + config 写进 profile patch（预设侧 enabled:false）→
+# 插件仍以 enabled:false 加载；把同样内容写进预设文件 → 立即生效。所以开关必须改
+# 已安装的预设文件：
+#
+#   $DSH_HOME/.agent-presets/kixparadigm/agent.cordis.yml
+#     - id: kix-webhook
+#       name: ./plugins/kix-webhook.js
+#       config:
+#         enabled: true
+#         workspacePath: /absolute/path/to/workspace   # 必须是已存在的绝对目录
+#         agentPreset: kixparadigm
+#         permissionPreset: danger-full-access
+#         events: ['pull_request.opened', 'issues.opened']
+#         ignoreSenders: ['*[bot]']
+#         maxSessions: 1                                # 失控 fuse：本进程最多起几个会话
+#         promptTemplate: '外部事件：{{event}} {{action}} {{repository}}#{{number}} {{url}}（sender {{sender}}）。按 kix 范式处理。'
+#
+# 本仓改法：直接改 dsh/preset/agent.cordis.yml 的同一行，然后跑安装/同步脚本
+# 重新物化到 $DSH_HOME/.agent-presets/kixparadigm（改仓 ≠ 改运行时副本）。
+#
+# 注意（lazy mount）：预设是在**首次有会话挂载它**时组装，插件在此之前不会加载。
+# 冷启动后、任何会话之前到来的 webhook 找不到已注册规则 → 只回 202、不起会话。
+# 需要「开机即能接事件」的部署，先开一个会话（或让常驻客户端保持一个会话）。
+#
+# ── 3. 写共享密钥 ──────────────────────────────────────────────────────────
+#
+# $DSH_HOME/.credentials.yaml 的 refs 段加一行（值 = GitHub webhook 里配的同一个 secret）：
+#   refs:
+#     KIX_WEBHOOK_SECRET: <random-32-hex>
+# 生成：openssl rand -hex 32
+# 注：这是**向已有文件追加**的片段；若该文件还不存在、要整份新建，宿主还需要
+# 顶层的 `version: 1`（见 dsh-credentials-local），否则加载失败。
+#
+# ── 4. 自测（本机回环，不需要公网）─────────────────────────────────────────
+#
+# TOKEN 从 `dsh web` 启动行里取；secret 与上面写入的一致：
+#
+#   BODY='{"action":"opened","number":1,"pull_request":{"number":1,"title":"probe"},"repository":{"full_name":"o/r"},"sender":{"login":"alice"}}'
+#   SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.*= //')
+#   curl -i -X POST "http://127.0.0.1:<port>/api/kix-webhook/github" \
+#     -H 'content-type: application/json' \
+#     -H "x-hub-signature-256: sha256=$SIG" \
+#     -H 'x-github-delivery: manual-1' \
+#     -H 'x-github-event: pull_request' \
+#     --data-binary "$BODY"
+#
+# 期望：HTTP 202；几秒后 $DSH_HOME/sessions/<cwd>/<webhook-session-id>/ 出现会话日志，
+# 首个 request/header 的 system 含 kix 常驻人格（kixParadigm / 三通道 / 需求三检）。
+# 2026-09-09 在 DSH 0.1.2-rc.1 上实测通过（含会话真实执行并回复）。
+#
+# ── 5. 外部可达性（部署面，未验证）──────────────────────────────────────────
+#
+# `dsh web` 默认只绑 127.0.0.1，GitHub 无法直接投递。要接真实事件需要
+# 隧道（cloudflared/ngrok）或反代暴露该路径，并在 GitHub 仓库 Webhook 里填
+# 公网 URL + 同一 secret + application/json。**这条路径本仓未验证**：
+# 上述自测证明的是「已验证投递 → kix 会话」链路，不是公网入口。
+#
+# ── 边界 ───────────────────────────────────────────────────────────────────
+#
+# - 不做持久化去重：GitHub 重投可能多起一个会话，由 maxSessions 兜底。
+# - 不做重试/队列：规则返回 null 即不动作。
+# - **202 不代表处理成功**（0.1.2 源码事实）：入口校验（方法/内容类型/签名/头）失败
+#   才会回 4xx/5xx；`dispatch()` 同步返回后适配器立刻回 202，规则执行与建会话是
+#   异步的，失败只写宿主日志（`dsh-webhook` 的 startInvocation catch → logger.warn）。
+#   所以别用 HTTP 状态判断会话是否起得来——要看 `$DSH_HOME/sessions/` 是否出现
+#   `webhook-*` 目录，或看宿主日志。
+# - 会话是**普通 root 会话**（会走 LLM、会花钱）：maxSessions 与 ignoreSenders
+#   是两道机械闸，不要为了「方便」把 maxSessions 调大。fuse 在返回请求**之前**
+#   自增，因此建会话失败也占名额（保守方向）。

--- a/dsh/preset/patches/kix-webhook.runtime-overlay.yml
+++ b/dsh/preset/patches/kix-webhook.runtime-overlay.yml
@@ -1,0 +1,25 @@
+# kix-webhook 运行时 overlay（`--patch` 覆盖层）
+#
+# 用途：把 webhook 的 HTTP 入口两行挂进任意 profile，而**不动** profile 自己的
+# cordis.patch.yml——0.1.1 及更早没有 @deepseek-ai/dsh-webhook，挂上去会让整棵
+# 插件树装不上（fail loud）。所以这一层只在升级到 0.1.2-rc.1 之后才用：
+#
+#   dsh web --patch /mnt/c/Users/37112/Desktop/kix-bundle/dsh/preset/patches/kix-webhook.runtime-overlay.yml
+#
+# 需要同时做的另一件事（见 kix-webhook.reference.yml §2）：把已安装预设
+# $DSH_HOME/.agent-presets/kixparadigm/agent.cordis.yml 里 kix-webhook 行的
+# config.enabled 改成 true（profile patch 覆盖不到 preset 内部行）。
+#
+# 前置：$DSH_HOME/.credentials.yaml 的 refs 里已有 KIX_WEBHOOK_SECRET
+# （2026-09-09 本机已生成并写入）。
+- insert:
+    - id: webhook-runtime
+      name: '@deepseek-ai/dsh-webhook'
+
+    - id: webhook-github
+      name: '@deepseek-ai/dsh-webhook-github'
+      config:
+        source: primary-github
+        path: /api/kix-webhook/github
+        secretEnv: KIX_WEBHOOK_SECRET
+        maxBodyBytes: 262144

--- a/dsh/preset/plugins/consistency-lib.cjs
+++ b/dsh/preset/plugins/consistency-lib.cjs
@@ -315,6 +315,10 @@ const PLUGIN_IDENTITY_GROUPS = {
   'kix-probe.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-settle.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-mem.js': [['kixparadigm', 'kixparadigm-null']],
+  // 2026-09-09：webhook 桥是部署面规则层（GitHub 适配器 → webhookRuntime → kix 会话），
+  // 不属范式认知面 → 只比激励面两副本。classic/en 档不部署（其 composition 不挂
+  // webhookRuntime，多一份副本只会变成悬空行）。
+  'kix-webhook.js': [['kixparadigm', 'kixparadigm-null']],
 }
 
 function pluginSourceName(name) {

--- a/dsh/preset/plugins/kix-webhook.js
+++ b/dsh/preset/plugins/kix-webhook.js
@@ -1,0 +1,186 @@
+// kix-webhook — 把外部事件（GitHub webhook）变成一个 kix 会话（DSH 0.1.2+ 原生能力）
+//
+// 定位：DSH 0.1.2 起提供宿主 `ctx.webhookRuntime`（`register(rule)` / `dispatch(delivery)`，
+// 唯一内置动作 = 在 Web Workspace 里创建普通 root Session）与 `@deepseek-ai/dsh-webhook-github`
+// 适配器（校验 GitHub 原始 body 的 HMAC 签名，投递后返回 202 不等规则结算）。本插件是
+// **规则层**：把一条已验证投递翻译成 `WebhookSessionRequest`，让 PR/issue 事件直接起一个
+// 按 kix 范式组合的会话，而不是等主线程轮询。
+//
+// 分层（不要在本插件里做的事）：
+//   - HTTP 入口/签名校验 = `dsh-webhook-github`（profile 侧 insert 行）
+//   - 会话创建与编排 = `ctx.webhookRuntime`（宿主面）
+//   - 规则（事件 → 会话请求、去重、并发闸）= 本插件
+// 这三层都缺席时本插件静默不注册（inject 保持 pending），不报错、不产生副作用。
+//
+// 2026-09-09 实测（WSL2，DSH 0.1.2-rc.1，隔离 DSH_HOME）：
+//   - 签名 POST /api/probe-webhook/github → 202 → 规则命中 → 新建 root Session
+//     （agentPreset=kixparadigm，system prompt 含 kixParadigm/三通道/需求三检）
+//   - 该会话真实执行：user/message(source.kind=webhook) → assistant/message "WEBHOOK-OK"
+//   结论：链路成立；**外部可达性另算**——`dsh web` 默认只绑 127.0.0.1，GitHub 真投递
+//   需要隧道或反代，属部署面，不在本插件职责内。
+//
+// 配置（**预设行**的 config，见 dsh/preset/patches/kix-webhook.reference.yml）：
+//   enabled            总开关，默认 false（部署侧显式打开）
+//   workspacePath      会话工作区绝对路径（必填；必须是已存在目录）
+//   agentPreset        会话组合，默认 kixparadigm
+//   permissionPreset   sandbox/approval 预置，默认 danger-full-access
+//   events             触发的事件名（默认 pull_request.opened / issues.opened）
+//   ignoreSenders      忽略的 sender.login（默认 github-actions[bot] / *[bot] 通配）
+//   maxSessions        本进程内最多由 webhook 起的会话数，默认 1（失控 fuse）
+//   promptTemplate     会话初始 prompt 模板，{{key}} 从投递上下文插值
+//
+// 启用必须改**预设文件**里的这一行（$DSH_HOME/.agent-presets/<preset>/agent.cordis.yml），
+// 不是 profile 的 cordis.patch.yml：2026-09-09 配置面探针实测 profile patch 覆盖不到
+// preset 组成内部的行（只覆盖 HTTP 入口那两行 insert）。详见 reference §2。
+// 另：预设是 lazy mount，首次有会话挂载它时本插件才加载——冷启动后、任何会话之前的
+// 投递只回 202、不起会话。
+//
+// 规则是负债：不做队列、不做重试、不做持久化去重（GitHub 自身按 delivery id 重投，
+// 重复投递最多多起一个会话，由 maxSessions 兜底）。需要更强保证时在部署侧加。
+
+'use strict'
+
+const DEFAULT_AGENT_PRESET = 'kixparadigm'
+const DEFAULT_PERMISSION_PRESET = 'danger-full-access'
+const DEFAULT_EVENTS = ['pull_request.opened', 'issues.opened']
+const DEFAULT_IGNORE_SENDERS = ['*[bot]']
+const DEFAULT_MAX_SESSIONS = 1
+const DEFAULT_PROMPT =
+  '外部事件触发：{{event}}（{{repository}}）。请按 kix 范式处理这个事件，先给出你的处理计划。'
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isAbsolute(value) {
+  if (!isNonEmptyString(value)) return false
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
+}
+
+// 通配匹配：只支持 '*' 前缀/后缀/全匹配（够用，不做正则——避免配置里注入模式）
+function matchesPattern(value, pattern) {
+  if (typeof value !== 'string' || typeof pattern !== 'string') return false
+  if (pattern === '*') return true
+  if (pattern.startsWith('*')) return value.endsWith(pattern.slice(1))
+  if (pattern.endsWith('*')) return value.startsWith(pattern.slice(0, -1))
+  return value === pattern
+}
+
+// 把 GitHub 投递压成插值上下文；payload 形状按事件不同，缺失字段一律空串
+function contextOf(delivery) {
+  const event = delivery && delivery.event ? delivery.event : {}
+  const payload = event && event.payload && typeof event.payload === 'object' ? event.payload : {}
+  const pr = payload.pull_request || {}
+  const issue = payload.issue || {}
+  const repo = payload.repository || {}
+  const sender = payload.sender || {}
+  return {
+    event: isNonEmptyString(event.name) ? event.name : '',
+    action: isNonEmptyString(payload.action) ? payload.action : '',
+    repository: isNonEmptyString(repo.full_name) ? repo.full_name : '',
+    sender: isNonEmptyString(sender.login) ? sender.login : '',
+    number: String(pr.number ?? issue.number ?? payload.number ?? ''),
+    title: isNonEmptyString(pr.title) ? pr.title : (isNonEmptyString(issue.title) ? issue.title : ''),
+    url: isNonEmptyString(pr.html_url) ? pr.html_url : (isNonEmptyString(issue.html_url) ? issue.html_url : ''),
+    delivery: isNonEmptyString(delivery && delivery.deliveryId) ? delivery.deliveryId : '',
+  }
+}
+
+// 模板插值：未命中的 key 保留原样（暴露配置错误，不静默吞掉）
+function renderTemplate(template, context) {
+  return String(template).replace(/\{\{([a-zA-Z0-9_]+)\}\}/g, (whole, key) =>
+    Object.prototype.hasOwnProperty.call(context, key) ? context[key] : whole)
+}
+
+function eventKey(delivery) {
+  const event = delivery && delivery.event ? delivery.event : {}
+  const payload = event && event.payload && typeof event.payload === 'object' ? event.payload : {}
+  const name = isNonEmptyString(event.name) ? event.name : ''
+  const action = isNonEmptyString(payload.action) ? payload.action : ''
+  return action ? `${name}.${action}` : name
+}
+
+function normalizeConfig(config) {
+  const raw = config && typeof config === 'object' ? config : {}
+  const events = Array.isArray(raw.events) && raw.events.length > 0
+    ? raw.events.filter(isNonEmptyString)
+    : DEFAULT_EVENTS.slice()
+  const ignoreSenders = Array.isArray(raw.ignoreSenders)
+    ? raw.ignoreSenders.filter(isNonEmptyString)
+    : DEFAULT_IGNORE_SENDERS.slice()
+  const maxSessions = Number.isSafeInteger(raw.maxSessions) && raw.maxSessions >= 0
+    ? raw.maxSessions
+    : DEFAULT_MAX_SESSIONS
+  return {
+    enabled: raw.enabled === true,
+    workspacePath: isNonEmptyString(raw.workspacePath) ? raw.workspacePath : undefined,
+    agentPreset: isNonEmptyString(raw.agentPreset) ? raw.agentPreset : DEFAULT_AGENT_PRESET,
+    permissionPreset: isNonEmptyString(raw.permissionPreset) ? raw.permissionPreset : DEFAULT_PERMISSION_PRESET,
+    events,
+    ignoreSenders,
+    maxSessions,
+    promptTemplate: isNonEmptyString(raw.promptTemplate) ? raw.promptTemplate : DEFAULT_PROMPT,
+  }
+}
+
+// 纯函数：投递 → 会话请求（null = 不动作）。测试直接打这个面。
+function decide(delivery, cfg, state) {
+  const config = normalizeConfig(cfg)
+  const counters = state && typeof state === 'object' ? state : { started: 0 }
+  if (!config.enabled) return null
+  if (!isAbsolute(config.workspacePath)) return null
+  if (typeof counters.started === 'number' && counters.started >= config.maxSessions) return null
+  if (!delivery || typeof delivery !== 'object') return null
+  const key = eventKey(delivery)
+  if (!config.events.some((pattern) => matchesPattern(key, pattern))) return null
+  const context = contextOf(delivery)
+  if (context.sender && config.ignoreSenders.some((pattern) => matchesPattern(context.sender, pattern))) return null
+  const prompt = renderTemplate(config.promptTemplate, context)
+  if (!isNonEmptyString(prompt)) return null
+  const title = context.number
+    ? `${context.event}#${context.number} ${context.title || context.action || ''}`.trim()
+    : `${context.event} ${context.action}`.trim()
+  return {
+    workspacePath: config.workspacePath,
+    title: title || 'webhook',
+    prompt,
+    agentPreset: config.agentPreset,
+    permissionPreset: config.permissionPreset,
+  }
+}
+
+const name = 'kix-webhook'
+
+function apply(ctx, config) {
+  const normalized = normalizeConfig(config)
+  if (!normalized.enabled) {
+    ctx.logger.info('kix-webhook: disabled (set enabled: true in the PRESET row config — $DSH_HOME/.agent-presets/<preset>/agent.cordis.yml — not the profile patch; see dsh/preset/patches/kix-webhook.reference.yml §2)')
+    return
+  }
+  if (!isAbsolute(normalized.workspacePath)) {
+    ctx.logger.warn('kix-webhook: workspacePath must be an absolute existing directory; rule not registered')
+    return
+  }
+  const state = { started: 0 }
+  ctx.inject(['webhookRuntime'], (scope) => {
+    scope.effect(() => {
+      const dispose = scope.webhookRuntime.register({
+        id: 'kix-webhook',
+        kind: 'github',
+        run(delivery) {
+          const request = decide(delivery, normalized, state)
+          if (request === null) {
+            ctx.logger.debug(`kix-webhook: delivery ${delivery && delivery.deliveryId} ignored`)
+            return null
+          }
+          state.started += 1
+          ctx.logger.info(`kix-webhook: starting session "${request.title}" (${state.started}/${normalized.maxSessions})`)
+          return request
+        },
+      })
+      return () => { void dispose() }
+    })
+  })
+}
+
+module.exports = { name, apply, decide, renderTemplate, matchesPattern, normalizeConfig, contextOf, eventKey }

--- a/dsh/preset/plugins/kix-webhook.test.js
+++ b/dsh/preset/plugins/kix-webhook.test.js
@@ -1,0 +1,153 @@
+'use strict'
+
+// kix-webhook 单元测试（2026-09-09）
+//
+// 测的是 decide() 的行为面：投递 → 会话请求（或 null）。不 mock webhookRuntime 的
+// 内部实现，只验证本插件自己的规则层（事件匹配/忽略名单/并发闸/插值/绝对路径闸）。
+// 真实链路（签名 HTTP → dispatch → 起会话 → 模型执行）由部署侧 E2E 覆盖，
+// 见插件头部注释的 2026-09-09 实测记录。
+
+const assert = require('node:assert/strict')
+const { test } = require('node:test')
+const plugin = require('./kix-webhook.js')
+
+function delivery(overrides = {}) {
+  const { name = 'pull_request', action = 'opened', payload = {}, ...rest } = overrides
+  return {
+    kind: 'github',
+    source: 'primary-github',
+    deliveryId: 'delivery-1',
+    receivedAt: 1_788_900_000_000,
+    event: {
+      name,
+      payload: {
+        action,
+        pull_request: { number: 42, title: 'add webhook bridge', html_url: 'https://github.com/o/r/pull/42' },
+        repository: { full_name: 'o/r' },
+        sender: { login: 'alice' },
+        ...payload,
+      },
+    },
+    ...rest,
+  }
+}
+
+const baseConfig = { enabled: true, workspacePath: '/tmp/ws', maxSessions: 1 }
+
+test('disabled config never starts a session', () => {
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, enabled: false }, { started: 0 }), null)
+})
+
+test('workspacePath must be absolute', () => {
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, workspacePath: 'relative/path' }, { started: 0 }), null)
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, workspacePath: undefined }, { started: 0 }), null)
+  assert.ok(plugin.decide(delivery(), { ...baseConfig, workspacePath: 'C:\\ws' }, { started: 0 }))
+})
+
+test('default events are pull_request.opened and issues.opened', () => {
+  assert.ok(plugin.decide(delivery(), baseConfig, { started: 0 }))
+  assert.ok(plugin.decide(delivery({ name: 'issues' }), baseConfig, { started: 0 }))
+  assert.equal(plugin.decide(delivery({ action: 'closed' }), baseConfig, { started: 0 }), null)
+  assert.equal(plugin.decide(delivery({ name: 'push', action: undefined }), baseConfig, { started: 0 }), null)
+})
+
+test('event patterns support prefix/suffix wildcards', () => {
+  const cfg = { ...baseConfig, events: ['pull_request.*'] }
+  assert.ok(plugin.decide(delivery({ action: 'synchronize' }), cfg, { started: 0 }))
+  assert.equal(plugin.decide(delivery({ name: 'issues' }), cfg, { started: 0 }), null)
+})
+
+test('bot senders are ignored by default', () => {
+  const bot = delivery({ payload: { sender: { login: 'dependabot[bot]' } } })
+  assert.equal(plugin.decide(bot, baseConfig, { started: 0 }), null)
+  assert.ok(plugin.decide(delivery({ payload: { sender: { login: 'alice' } } }), baseConfig, { started: 0 }))
+})
+
+test('maxSessions acts as a fuse', () => {
+  assert.equal(plugin.decide(delivery(), baseConfig, { started: 1 }), null)
+  assert.ok(plugin.decide(delivery(), { ...baseConfig, maxSessions: 2 }, { started: 1 }))
+  assert.equal(plugin.decide(delivery(), { ...baseConfig, maxSessions: 0 }, { started: 0 }), null)
+})
+
+test('request carries the configured preset surface and a rendered title', () => {
+  const request = plugin.decide(delivery(), baseConfig, { started: 0 })
+  assert.equal(request.workspacePath, '/tmp/ws')
+  assert.equal(request.agentPreset, 'kixparadigm')
+  assert.equal(request.permissionPreset, 'danger-full-access')
+  assert.equal(request.title, 'pull_request#42 add webhook bridge')
+  assert.match(request.prompt, /pull_request/)
+  assert.match(request.prompt, /o\/r/)
+})
+
+test('promptTemplate interpolates delivery context and keeps unknown keys literal', () => {
+  const rendered = plugin.renderTemplate('{{event}} {{action}} {{number}} {{missing}}', {
+    event: 'issues', action: 'opened', number: '7',
+  })
+  assert.equal(rendered, 'issues opened 7 {{missing}}')
+})
+
+test('malformed deliveries are ignored instead of throwing', () => {
+  assert.equal(plugin.decide(null, baseConfig, { started: 0 }), null)
+  assert.equal(plugin.decide({}, baseConfig, { started: 0 }), null)
+  assert.equal(plugin.decide({ event: {} }, baseConfig, { started: 0 }), null)
+})
+
+test('apply while disabled returns before injecting (no service lookup, one log)', () => {
+  const logs = []
+  const ctx = {
+    logger: { info: (m) => logs.push(['info', m]), warn: (m) => logs.push(['warn', m]), debug: () => {} },
+    inject: () => { throw new Error('should not inject while disabled') },
+  }
+  plugin.apply(ctx, { enabled: false })
+  assert.equal(logs.length, 1)
+  assert.match(logs[0][1], /disabled/)
+  // 提示必须指向**预设行**（profile patch 覆盖不到 preset 内部行，实测 2026-09-09）
+  assert.match(logs[0][1], /PRESET row/)
+})
+
+// enabled=true 但宿主没有 webhookRuntime（0.1.1 及更早）时：插件不得抛错，
+// 只调用一次 inject 并就此停住（cordis 语义：依赖未满足的 fiber 保持 pending，
+// 服务出现后再执行回调）。本用例只证明「不抛错 + 恰好一次 inject + 无注册」；
+// 真正的 pending→恢复语义属宿主 cordis，不在本单测覆盖范围内。
+test('apply with enabled=true but no webhookRuntime stays pending without throwing', () => {
+  const logs = []
+  const injects = []
+  const ctx = {
+    logger: { info: (m) => logs.push(['info', m]), warn: (m) => logs.push(['warn', m]), debug: () => {} },
+    inject: (services, cb) => { injects.push(services); return { dispose() {} } },
+  }
+  assert.doesNotThrow(() => plugin.apply(ctx, { enabled: true, workspacePath: '/tmp/ws' }))
+  assert.equal(injects.length, 1)
+  assert.deepEqual(injects[0], ['webhookRuntime'])
+  assert.equal(logs.length, 0)
+})
+
+test('apply refuses a non-absolute workspacePath before injecting', () => {
+  const logs = []
+  let injected = false
+  const ctx = {
+    logger: { info: () => {}, warn: (m) => logs.push(m), debug: () => {} },
+    inject: () => { injected = true },
+  }
+  plugin.apply(ctx, { enabled: true, workspacePath: 'relative' })
+  assert.equal(injected, false)
+  assert.match(logs[0], /absolute/)
+})
+
+test('apply registers a github rule that honours the session fuse', () => {
+  const registered = []
+  const scope = {
+    effect: (fn) => { fn(); return () => {} },
+    webhookRuntime: { register: (rule) => { registered.push(rule); return () => {} } },
+  }
+  const ctx = {
+    logger: { info: () => {}, warn: () => {}, debug: () => {} },
+    inject: (services, cb) => { assert.deepEqual(services, ['webhookRuntime']); cb(scope) },
+  }
+  plugin.apply(ctx, { enabled: true, workspacePath: '/tmp/ws', maxSessions: 1 })
+  assert.equal(registered.length, 1)
+  assert.equal(registered[0].id, 'kix-webhook')
+  assert.equal(registered[0].kind, 'github')
+  assert.ok(registered[0].run(delivery(), new AbortController().signal))
+  assert.equal(registered[0].run(delivery(), new AbortController().signal), null)
+})

--- a/en/package.json
+++ b/en/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kixparadigm-en",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "kixparadigm-en — English edition of the kix paradigm preset for DeepSeek Harness: resident cognition layer (EN) + kixpower multi-agent orchestration, one-command import (preset + vision-bridge + guard plugins)",
   "license": "MIT",
   "author": "kix (olicesx)",

--- a/en/preset-classic-en/plugins/consistency-lib.cjs
+++ b/en/preset-classic-en/plugins/consistency-lib.cjs
@@ -315,6 +315,10 @@ const PLUGIN_IDENTITY_GROUPS = {
   'kix-probe.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-settle.js': [['kixparadigm', 'kixparadigm-null']],
   'kix-mem.js': [['kixparadigm', 'kixparadigm-null']],
+  // 2026-09-09：webhook 桥是部署面规则层（GitHub 适配器 → webhookRuntime → kix 会话），
+  // 不属范式认知面 → 只比激励面两副本。classic/en 档不部署（其 composition 不挂
+  // webhookRuntime，多一份副本只会变成悬空行）。
+  'kix-webhook.js': [['kixparadigm', 'kixparadigm-null']],
 }
 
 function pluginSourceName(name) {

--- a/en/scripts/check-consistency.cjs
+++ b/en/scripts/check-consistency.cjs
@@ -11,7 +11,7 @@ const lib = require('../preset-classic-en/plugins/consistency-lib.cjs')
 
 const ROOT = path.join(__dirname, '..')
 
-const { failures, notes } = lib.runAllEn(ROOT, '1.3.13')
+const { failures, notes } = lib.runAllEn(ROOT, '1.3.14')
 for (const n of notes) console.log('  ✔ ' + n)
 
 if (failures.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kixparadigm",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "kixparadigm — AI 自编排最小范式（认知层常驻）+ kixpower 多智能体编排 + DSH 一键导入（preset + vision-bridge + 门禁插件）",
   "license": "MIT",
   "author": "kix (olicesx)",


### PR DESCRIPTION
## 内容

DSH 0.1.2 原生能力对接（三项，见 CHANGELOG v1.3.14）：

1. **`web_fetch` 打开** —— `tool-web.config.fetch: true`。0.1.2 宿主默认挂载 SSRF 加固的 `dsh-web-fetch-http`（公网地址校验/连接固定/同源重定向/字节上限），0.1.1 关闭的理由已消失。实测 `web_fetch https://example.com` → HTTP 200 + 解码正文。
2. **`kix-webhook`：外部事件 → kix 会话（发布默认关）** —— 规则层插件 + 13 条单测；`enabled: false`，激励面两副本字节一致；classic/en 不部署（组成不挂 webhookRuntime）。实测签名 POST → 202 → 新建 `webhook-*` 会话（preset=kixparadigm，system prompt 含 kixParadigm）→ 会话真实执行。
3. **原生子代理模型选型：验证可用、不默认开** —— 两条机械理由（宿主缺 settings 行时挂载即抛错；白名单绑机器）写在 README-DSH。

## 新增机制事实（实测）

- profile 的 patch 覆盖不到 preset 组成内部的行 → 启用必须改预设文件
- 预设是 lazy mount：冷启动无会话时投递只回 202、不起会话
- 202 ≠ 处理成功：入口校验失败才回 4xx/5xx，规则/建会话失败只写宿主日志

## 门禁

- `npm test` 50 pass / 0 fail / 1 skip
- `check-dsh-consistency` CONSISTENCY OK（`kix-webhook.js/.test.js: 2 copies byte-identical`）
- `kix4.test.js` composition parity PASS（default/null 均 33 行）
- `audit-selection-pressure-history --check` exit 0
- 0.1.2-rc.1 端到端复验：web_fetch + webhook→会话
- 独立观察者只读复核 4 findings 全部修复